### PR TITLE
feat: Add checkpoint store, service principal auth, and topic/subscription

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/extensions/eda/plugins/event_source/azure_event_hub.py
+++ b/extensions/eda/plugins/event_source/azure_event_hub.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from azure.eventhub import EventData
 from azure.eventhub.aio import EventHubConsumerClient, PartitionContext
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
 from azure.identity.aio import ClientSecretCredential
 
 DOCUMENTATION = r"""
@@ -60,14 +61,39 @@ options:
     required: true
   azure_starting_position:
     description:
-      - The starting position
+      - The starting position valid values are -1, @latest, integer position
+        or datetime. https://azuresdkdocs.z19.web.core.windows.net/python/azure-eventhub/latest/azure.eventhub.html
     type: str
-    default: "-1"
+    default: "@latest"
+
   azure_consumer_group:
     description:
       - The name of the consumer group
     type: str
     default: "$Default"
+  azure_storage_account_name:
+    description:
+      - The Azure Storage Account name for persisting checkpoints
+      - Uses the same service principal credentials as Event Hub
+      - If not provided, checkpoints will only be stored in-memory
+      - Example "mystorageaccount" (not the full URL)
+    type: str
+    required: false
+  azure_checkpoint_container_name:
+    description:
+      - The name of the blob container to store checkpoints
+      - Required if azure_storage_account_name is provided
+    type: str
+    required: false
+  azure_max_wait_time:
+    description:
+      - Maximum time in seconds to wait for events before checking for partition rebalancing
+      - Lower values (10-30) = faster failover detection but more Azure API calls
+      - Higher values (60-120) = slower failover but fewer API calls and lower costs
+      - Only relevant when using load balancing (multiple consumers with same consumer group)
+    type: int
+    default: 60
+    required: false
   feedback:
     type: bool
     default: false
@@ -101,7 +127,10 @@ EXAMPLES = r"""
     "azure_client_secret": "your_client_secret"
     "azure_namespace": "example.servicebus.windows.net"
     "azure_event_hub_name": "your_hub_name"
-    "azure_starting_position": "-1"
+    "azure_consumer_group": "$Default"
+    "azure_starting_position": "@latest"
+    "azure_storage_account_name": "mystorageaccount"
+    "azure_checkpoint_container_name": "eventhub-checkpoints"
 """
 
 logger = logging.getLogger()
@@ -117,9 +146,10 @@ def is_valid_uuid(value: str) -> bool:
     """
     try:
         uuid.UUID(value)
-        return True  # noqa: TRY300
     except (ValueError, AttributeError, TypeError):
         return False
+    else:
+        return True
 
 
 def _normalize_amqp_id(value: str | bytes | uuid.UUID | int | None) -> str | None:
@@ -200,16 +230,36 @@ class AzureHubConsumer:
         self.event_hub_name = args.get("azure_event_hub_name")
 
         self.consumer_group = args.get("azure_consumer_group", "$Default")
-        self.starting_position = int(args.get("azure_starting_position", "-1"))
-        self.feedback_timeout = int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT))
+        raw_position = args.get("azure_starting_position", "@latest")
+        try:
+            self.starting_position = int(raw_position)
+        except (ValueError, TypeError):
+            self.starting_position = raw_position
+        self.feedback_timeout = int(
+            args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT),
+        )
         self.feedback = args.get("feedback", False)
         self.eda_feedback_queue = args.get("eda_feedback_queue")
+
+        # Load balancing configuration - lower values = faster failover
+        self.max_wait_time = int(args.get("azure_max_wait_time", 60))
+
+        # Blob Storage for checkpoint persistence
+        self.storage_account_name = args.get("azure_storage_account_name")
+        self.checkpoint_container_name = args.get("azure_checkpoint_container_name")
 
         if self.feedback and self.eda_feedback_queue is None:
             msg = (
                 "feedback: true was set but no feedback queue was provided. "
                 "This requires a compatible version of ansible-rulebook that "
                 "supports the feedback mechanism."
+            )
+            raise ValueError(msg)
+
+        if self.storage_account_name and not self.checkpoint_container_name:
+            msg = (
+                "azure_checkpoint_container_name is required when "
+                "azure_storage_account_name is provided"
             )
             raise ValueError(msg)
 
@@ -220,7 +270,9 @@ class AzureHubConsumer:
         )
 
     async def on_event(
-        self, partition_context: PartitionContext, event: EventData,
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
     ) -> None:
         """Receiving event data."""
         if event:
@@ -267,14 +319,70 @@ class AzureHubConsumer:
 
     async def start_receiving(self) -> None:
         """Start receiving data."""
+        # Create checkpoint store if blob storage is configured
+        checkpoint_store = None
+        if self.storage_account_name and self.checkpoint_container_name:
+            # Use service principal credentials for blob storage
+            blob_account_url = (
+                f"https://{self.storage_account_name}.blob.core.windows.net"
+            )
+            checkpoint_store = BlobCheckpointStore(
+                blob_account_url=blob_account_url,
+                container_name=self.checkpoint_container_name,
+                credential=self.credential,
+            )
+            logger.info(
+                "Using persistent checkpoint store with container: %s in account: %s",
+                self.checkpoint_container_name,
+                self.storage_account_name,
+            )
+        else:
+            logger.warning(
+                "No checkpoint store configured. Checkpoints will be in-memory only. "
+                "Consumer will restart from '%s' position on each restart.",
+                self.starting_position,
+            )
+
+        logger.info(
+            "Starting Azure Event Hub consumer - Namespace: '%s', Event Hub: '%s', "
+            "Consumer Group: '%s', Starting Position: '%s'",
+            self.event_hub_namespace,
+            self.event_hub_name,
+            self.consumer_group,
+            (
+                self.starting_position
+                if checkpoint_store is None
+                else "from checkpoint or earliest"
+            ),
+        )
+
         client = EventHubConsumerClient(
             fully_qualified_namespace=self.event_hub_namespace,
             eventhub_name=self.event_hub_name,
             consumer_group=self.consumer_group,
             credential=self.credential,
+            checkpoint_store=checkpoint_store,
         )
+
+        # Configure receive arguments
+        receiver_args = {
+            "on_event": self.on_event,
+            "max_wait_time": self.max_wait_time,  # Controls load balancing interval
+        }
+
+        # IMPORTANT: Only pass starting_position when checkpoint_store is None
+        # The Azure SDK has known issues with parameter precedence (see GitHub issue #17297)
+        # where passing starting_position alongside checkpoint_store can cause the SDK to
+        # prioritize starting_position over existing checkpoints, contrary to documented behavior.
+        # By NOT passing starting_position when checkpoint_store exists, the SDK correctly:
+        # - Resumes from checkpoint if one exists
+        # - Uses SDK default (earliest) if no checkpoint exists
+        # We only pass starting_position for in-memory checkpoint mode (no checkpoint_store).
+        if checkpoint_store is None:
+            receiver_args["starting_position"] = self.starting_position
+
         async with client:
-            await client.receive(self.on_event)
+            await client.receive(**receiver_args)
 
 
 # Usage
@@ -307,7 +415,10 @@ if __name__ == "__main__":
         "azure_client_secret": "your_client_secret",
         "azure_namespace": "example.servicebus.windows.net",
         "azure_event_hub_name": "your_hub_name",
-        "azure_starting_position": "-1",
+        "azure_consumer_group": "$Default",
+        "azure_starting_position": "@latest",
+        "azure_storage_account_name": "mystorageaccount",
+        "azure_checkpoint_container_name": "eventhub-checkpoints",
     }
 
     asyncio.run(

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -9,19 +9,23 @@ events into Ansible EDA rulebooks.
 
 import asyncio
 import contextlib
+import dataclasses
 import json
 import logging
 import uuid
 from typing import Any
 
+from azure.identity.aio import ClientSecretCredential
 from azure.servicebus import ServiceBusReceivedMessage
-from azure.servicebus.aio import ServiceBusClient
+from azure.servicebus.aio import ServiceBusClient, ServiceBusReceiver
 
 DOCUMENTATION = r"""
 ---
 short_description: Receive events from an Azure service bus.
 description:
   - An ansible-rulebook event source module for receiving events from an Azure service bus.
+  - Supports both connection string and service principal authentication.
+  - Can receive from queues or topic subscriptions.
   - In order to get the service bus and the connection string, refer to
     https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-queues?tabs=passwordless
   - Each event is assigned a valid RFC 4122 UUID under meta.uuid.
@@ -33,13 +37,51 @@ options:
   conn_str:
     description:
       - The connection string to connect to the Azure service bus.
+      - Either conn_str OR (tenant_id, client_id, client_secret, namespace) must be provided.
     type: str
-    required: true
+    required: false
+  azure_tenant_id:
+    description:
+      - Azure Active Directory tenant ID for service principal authentication.
+      - Required if conn_str is not provided.
+    type: str
+    required: false
+  azure_client_id:
+    description:
+      - Azure service principal client ID (application ID).
+      - Required if conn_str is not provided.
+    type: str
+    required: false
+  azure_client_secret:
+    description:
+      - Azure service principal client secret.
+      - Required if conn_str is not provided.
+    type: str
+    required: false
+  azure_namespace:
+    description:
+      - Azure Service Bus namespace (e.g., 'myservicebus.servicebus.windows.net').
+      - Required if conn_str is not provided.
+    type: str
+    required: false
   queue_name:
     description:
       - The name of the queue to pull messages from.
+      - Either queue_name OR (azure_topic_name AND azure_subscription_name) must be provided.
     type: str
-    required: true
+    required: false
+  azure_topic_name:
+    description:
+      - The name of the topic to pull messages from.
+      - Requires azure_subscription_name to be set.
+    type: str
+    required: false
+  azure_subscription_name:
+    description:
+      - The name of the subscription under the topic.
+      - Requires azure_topic_name to be set.
+    type: str
+    required: false
   logging_enable:
     description:
       - Whether to turn on logging.
@@ -72,9 +114,28 @@ options:
 """
 
 EXAMPLES = r"""
+# Using connection string with queue
 - azure.azcollection.azure_service_bus:
     conn_str: "{{connection_str}}"
     queue_name: "{{queue_name}}"
+
+# Using service principal with queue
+- azure.azcollection.azure_service_bus:
+    azure_tenant_id: "{{tenant_id}}"
+    azure_client_id: "{{client_id}}"
+    azure_client_secret: "{{client_secret}}"
+    azure_namespace: "myservicebus.servicebus.windows.net"
+    queue_name: "my-queue"
+    feedback: true
+
+# Using service principal with topic subscription
+- azure.azcollection.azure_service_bus:
+    azure_tenant_id: "{{tenant_id}}"
+    azure_client_id: "{{client_id}}"
+    azure_client_secret: "{{client_secret}}"
+    azure_namespace: "myservicebus.servicebus.windows.net"
+    azure_topic_name: "my-topic"
+    azure_subscription_name: "my-subscription"
 """
 
 DEFAULT_FEEDBACK_TIMEOUT = 120
@@ -92,9 +153,10 @@ def is_valid_uuid(value: str) -> bool:
     """
     try:
         uuid.UUID(value)
-        return True  # noqa: TRY300
     except (ValueError, AttributeError, TypeError):
         return False
+    else:
+        return True
 
 
 def _process_service_bus_uuid(
@@ -116,7 +178,9 @@ def _process_service_bus_uuid(
     if raw_id and is_valid_uuid(raw_id):
         meta["uuid"] = raw_id
     else:
-        meta["uuid"] = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{queue_name}:{msg.sequence_number}"))
+        meta["uuid"] = str(
+            uuid.uuid5(uuid.NAMESPACE_OID, f"{queue_name}:{msg.sequence_number}"),
+        )
         if raw_id and not _uuid_warning["emitted"]:
             _uuid_warning["emitted"] = True
             logger.warning(
@@ -126,54 +190,199 @@ def _process_service_bus_uuid(
             )
 
 
-async def receive_events(
-    queue: asyncio.Queue[Any],
-    args: dict[str, Any],  # pylint: disable=W0621
-) -> None:
-    """Receive events from service bus asynchronously."""
-    feedback_enabled = args.get("feedback", False)
-    eda_feedback_queue = args.get("eda_feedback_queue")
-    feedback_timeout = int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT))
+@dataclasses.dataclass(frozen=True)
+class _FeedbackConfig:
+    enabled: bool
+    queue: asyncio.Queue[Any] | None
+    timeout: int
 
-    if feedback_enabled and eda_feedback_queue is None:
+
+def _create_service_bus_client(args: dict[str, Any]) -> ServiceBusClient:
+    """Create Service Bus client with connection string or service principal.
+
+    Args:
+        args: Configuration arguments containing either conn_str or service principal credentials.
+
+    Returns:
+        ServiceBusClient instance.
+
+    Raises:
+        ValueError: If neither connection string nor service principal credentials are provided.
+
+    """
+    logging_enable = bool(args.get("logging_enable", True))
+
+    # Option 1: Connection string authentication (backward compatible)
+    if "conn_str" in args:
+        return ServiceBusClient.from_connection_string(
+            conn_str=args["conn_str"],
+            logging_enable=logging_enable,
+        )
+
+    # Option 2: Service principal authentication
+    tenant_id = args.get("azure_tenant_id")
+    client_id = args.get("azure_client_id")
+    client_secret = args.get("azure_client_secret")
+    namespace = args.get("azure_namespace")
+
+    if all([tenant_id, client_id, client_secret, namespace]):
+        credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        return ServiceBusClient(
+            fully_qualified_namespace=namespace,
+            credential=credential,
+            logging_enable=logging_enable,
+        )
+
+    # Neither method provided
+    msg = (
+        "Either 'conn_str' OR ('azure_tenant_id', 'azure_client_id', "
+        "'azure_client_secret', 'azure_namespace') must be provided"
+    )
+    raise ValueError(msg)
+
+
+def _validate_receive_args(args: dict[str, Any]) -> None:
+    """Validate feedback and queue/topic configuration."""
+    if args.get("feedback", False) and args.get("eda_feedback_queue") is None:
         msg = (
             "feedback: true was set but no feedback queue was provided. "
             "This requires a compatible version of ansible-rulebook that "
             "supports the feedback mechanism."
         )
         raise ValueError(msg)
-    servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=args["conn_str"],
-        logging_enable=bool(args.get("logging_enable", True)),
+
+    queue_name = args.get("queue_name")
+    azure_topic_name = args.get("azure_topic_name")
+    azure_subscription_name = args.get("azure_subscription_name")
+
+    if queue_name and (azure_topic_name or azure_subscription_name):
+        msg = "Cannot specify both queue_name and azure_topic_name/azure_subscription_name"
+        raise ValueError(msg)
+
+    if not queue_name and not (azure_topic_name and azure_subscription_name):
+        msg = "Either queue_name OR (azure_topic_name AND azure_subscription_name) must be provided"
+        raise ValueError(msg)
+
+
+def _get_receiver(
+    servicebus_client: ServiceBusClient,
+    args: dict[str, Any],
+) -> ServiceBusReceiver:
+    """Get the appropriate receiver based on queue or topic/subscription config."""
+    queue_name = args.get("queue_name")
+    namespace = args.get("azure_namespace", "connection-string-based")
+
+    if queue_name:
+        logger.info(
+            "Starting Azure Service Bus consumer - Namespace: '%s', Queue: '%s'",
+            namespace,
+            queue_name,
+        )
+        return servicebus_client.get_queue_receiver(queue_name=queue_name)
+
+    azure_topic_name = args.get("azure_topic_name")
+    azure_subscription_name = args.get("azure_subscription_name")
+    logger.info(
+        "Starting Azure Service Bus consumer - Namespace: '%s', Topic: '%s', Subscription: '%s'",
+        namespace,
+        azure_topic_name,
+        azure_subscription_name,
+    )
+    return servicebus_client.get_subscription_receiver(
+        topic_name=azure_topic_name,
+        subscription_name=azure_subscription_name,
     )
 
+
+async def _process_message(
+    msg: ServiceBusReceivedMessage,
+    receiver: ServiceBusReceiver,
+    queue: asyncio.Queue[Any],
+    feedback: _FeedbackConfig,
+    destination_name: str,
+) -> None:
+    """Process a single Service Bus message."""
+    meta: dict[str, Any] = {}
+    if msg.enqueued_time_utc:
+        meta["produced_at"] = msg.enqueued_time_utc.isoformat()
+    _process_service_bus_uuid(msg, destination_name, meta)
+
+    body = str(msg)
+    with contextlib.suppress(json.JSONDecodeError):
+        body = json.loads(body)
+
+    await queue.put({"body": body, "meta": meta})
+
+    if feedback.enabled and feedback.queue:
+        try:
+            await asyncio.wait_for(
+                feedback.queue.get(),
+                timeout=feedback.timeout,
+            )
+            await receiver.complete_message(msg)
+            logger.debug("Message %s completed successfully", msg.message_id)
+        except asyncio.TimeoutError:
+            logger.exception(
+                "Timed out waiting for feedback for message %s - dead lettering",
+                msg.message_id,
+            )
+            await receiver.dead_letter_message(
+                msg,
+                reason="FeedbackTimeout",
+                error_description=f"No acknowledgment received within {feedback.timeout}s",
+            )
+            raise
+    else:
+        await receiver.complete_message(msg)
+        logger.debug("Message %s completed (no feedback)", msg.message_id)
+
+
+async def receive_events(
+    queue: asyncio.Queue[Any],
+    args: dict[str, Any],  # pylint: disable=W0621
+) -> None:
+    """Receive events from service bus asynchronously."""
+    _validate_receive_args(args)
+
+    feedback = _FeedbackConfig(
+        enabled=args.get("feedback", False),
+        queue=args.get("eda_feedback_queue"),
+        timeout=int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT)),
+    )
+
+    servicebus_client = _create_service_bus_client(args)
+
     async with servicebus_client:
-        receiver = servicebus_client.get_queue_receiver(queue_name=args["queue_name"])
+        receiver = _get_receiver(servicebus_client, args)
         async with receiver:
+            destination_name = args.get("queue_name") or args.get(
+                "azure_topic_name", "unknown",
+            )
             async for msg in receiver:
-                meta: dict[str, Any] = {}
-                if msg.enqueued_time_utc:
-                    meta["produced_at"] = msg.enqueued_time_utc.isoformat()
-                _process_service_bus_uuid(msg, args["queue_name"], meta)
-
-                body = str(msg)
-                with contextlib.suppress(json.JSONDecodeError):
-                    body = json.loads(body)
-
-                await queue.put({"body": body, "meta": meta})
-
-                if feedback_enabled and eda_feedback_queue:
+                try:
+                    await _process_message(
+                        msg, receiver, queue, feedback, destination_name,
+                    )
+                except Exception as e:
+                    logger.exception("Error processing message %s", msg.message_id)
                     try:
-                        await asyncio.wait_for(
-                            eda_feedback_queue.get(),
-                            timeout=feedback_timeout,
+                        await receiver.dead_letter_message(
+                            msg,
+                            reason="ProcessingError",
+                            error_description=str(e)[:4096],
                         )
-                        await receiver.complete_message(msg)
-                    except asyncio.TimeoutError:
-                        logger.exception("Timed out waiting for feedback")
-                        raise
-                else:
-                    await receiver.complete_message(msg)
+                        logger.exception(
+                            "Message %s dead-lettered due to error", msg.message_id,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to dead-letter message %s", msg.message_id,
+                        )
+                    raise
 
 
 async def main(
@@ -194,8 +403,30 @@ if __name__ == "__main__":
             """Print the event."""
             print(event)  # noqa: T201
 
-    args = {
+    # Example 1: Using connection string with queue
+    args_conn_str = {
         "conn_str": "Endpoint=sb://foo.servicebus.windows.net/",
         "queue_name": "eda-queue",
     }
-    asyncio.run(main(MockQueue(), args))
+
+    # Example 2: Using service principal with queue
+    args_service_principal_queue = {
+        "azure_tenant_id": "your_tenant_id",
+        "azure_client_id": "your_client_id",
+        "azure_client_secret": "your_client_secret",
+        "azure_namespace": "myservicebus.servicebus.windows.net",
+        "queue_name": "eda-queue",
+    }
+
+    # Example 3: Using service principal with topic subscription
+    args_service_principal_topic = {
+        "azure_tenant_id": "your_tenant_id",
+        "azure_client_id": "your_client_id",
+        "azure_client_secret": "your_client_secret",
+        "azure_namespace": "myservicebus.servicebus.windows.net",
+        "azure_topic_name": "my-topic",
+        "azure_subscription_name": "my-subscription",
+    }
+
+    # Run with connection string example
+    asyncio.run(main(MockQueue(), args_conn_str))

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -213,7 +213,7 @@ def _create_service_bus_client(args: dict[str, Any]) -> ServiceBusClient:
     logging_enable = bool(args.get("logging_enable", True))
 
     # Option 1: Connection string authentication (backward compatible)
-    if "conn_str" in args:
+    if args.get("conn_str"):
         return ServiceBusClient.from_connection_string(
             conn_str=args["conn_str"],
             logging_enable=logging_enable,
@@ -327,13 +327,8 @@ async def _process_message(
             logger.debug("Message %s completed successfully", msg.message_id)
         except asyncio.TimeoutError:
             logger.exception(
-                "Timed out waiting for feedback for message %s - dead lettering",
+                "Timed out waiting for feedback for message %s",
                 msg.message_id,
-            )
-            await receiver.dead_letter_message(
-                msg,
-                reason="FeedbackTimeout",
-                error_description=f"No acknowledgment received within {feedback.timeout}s",
             )
             raise
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ azure-common==1.1.28
 azure-containerregistry==1.2.0
 azure-core==1.38.0
 azure-eventhub==5.15.0
+azure-eventhub-checkpointstoreblob-aio==1.2.0
 azure-identity==1.25.2
 azure-iot-hub==2.6.1; platform_machine == "x86_64" and python_version < "3.14"
 azure-keyvault==4.2.0

--- a/tests/unit/event_source/test_azure_event_hub.py
+++ b/tests/unit/event_source/test_azure_event_hub.py
@@ -1,7 +1,7 @@
 import asyncio
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Type
+from typing import Any, Self
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,10 +15,17 @@ from extensions.eda.plugins.event_source.azure_event_hub import (
 VALID_UUID_1 = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
 VALID_UUID_2 = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
 
-PATCH_CREDENTIAL = "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
-PATCH_CLIENT = "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient"
+PATCH_CREDENTIAL = (
+    "extensions.eda.plugins.event_source.azure_event_hub.ClientSecretCredential"
+)
+PATCH_CLIENT = (
+    "extensions.eda.plugins.event_source.azure_event_hub.EventHubConsumerClient"
+)
+PATCH_BLOB_STORE = (
+    "extensions.eda.plugins.event_source.azure_event_hub.BlobCheckpointStore"
+)
 
-BASE_ARGS: Dict[str, Any] = {
+BASE_ARGS: dict[str, Any] = {
     "azure_tenant_id": "test_tenant_id",
     "azure_client_id": "test_client_id",
     "azure_client_secret": "test_client_secret",
@@ -57,19 +64,22 @@ class MockPartitionContext:
 class MockEventHubConsumerClient:
     def __init__(self, events: list[MockEvent]) -> None:
         self.events = events
+        self.receive_kwargs: dict[str, Any] = {}
 
-    async def __aenter__(self) -> "MockEventHubConsumerClient":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Any,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
     ) -> None:
         pass
 
-    async def receive(self, on_event_callback) -> None:
+    async def receive(self, **kwargs: Any) -> None:
+        self.receive_kwargs = kwargs
+        on_event_callback = kwargs["on_event"]
         partition_context = MockPartitionContext()
         for event in self.events:
             await on_event_callback(partition_context, event)
@@ -82,7 +92,9 @@ def reset_uuid_warning():
     _uuid_warning["emitted"] = False
 
 
-def _make_consumer(queue: asyncio.Queue, extra_args: Dict[str, Any] | None = None) -> AzureHubConsumer:
+def _make_consumer(
+    queue: asyncio.Queue, extra_args: dict[str, Any] | None = None
+) -> AzureHubConsumer:
     args = {**BASE_ARGS, **(extra_args or {})}
     with patch(PATCH_CREDENTIAL):
         return AzureHubConsumer(queue, args)
@@ -92,10 +104,11 @@ def _make_consumer(queue: asyncio.Queue, extra_args: Dict[str, Any] | None = Non
 # main() / required args
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_main_missing_required_args() -> None:
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {"azure_tenant_id": "test_tenant"}
+    args: dict[str, Any] = {"azure_tenant_id": "test_tenant"}
 
     with pytest.raises(ValueError, match="Please provide azure_client_id"):
         await main(queue, args)
@@ -105,7 +118,9 @@ async def test_main_missing_required_args() -> None:
 async def test_main_with_all_required_args() -> None:
     queue: asyncio.Queue[Any] = asyncio.Queue()
 
-    with patch(PATCH_CLIENT) as mock_client_class, patch(PATCH_CREDENTIAL) as mock_credential:
+    with patch(PATCH_CLIENT) as mock_client_class, patch(
+        PATCH_CREDENTIAL
+    ) as mock_credential:
         mock_client = AsyncMock()
         mock_client_class.return_value = mock_client
         mock_client.__aenter__.return_value = mock_client
@@ -126,9 +141,9 @@ async def test_main_with_all_required_args() -> None:
 # UUID assignment — string IDs
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_on_event_no_message_id_generates_uuid5() -> None:
-    """No message_id or correlation_id → deterministic UUID5 from partition:sequence."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"message": "Hello World"}')
@@ -143,7 +158,6 @@ async def test_on_event_no_message_id_generates_uuid5() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_valid_uuid_message_id() -> None:
-    """Valid UUID message_id is used directly as meta.uuid."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1)
@@ -157,7 +171,6 @@ async def test_on_event_valid_uuid_message_id() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_valid_uuid_correlation_id() -> None:
-    """Valid UUID correlation_id is used when message_id is absent."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"data": "test"}', correlation_id=VALID_UUID_2)
@@ -171,10 +184,11 @@ async def test_on_event_valid_uuid_correlation_id() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_message_id_takes_precedence_over_correlation_id() -> None:
-    """message_id wins over correlation_id when both are valid UUIDs."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
-    event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1, correlation_id=VALID_UUID_2)
+    event = MockEvent(
+        '{"data": "test"}', message_id=VALID_UUID_1, correlation_id=VALID_UUID_2
+    )
 
     await consumer.on_event(MockPartitionContext(), event)
 
@@ -183,14 +197,13 @@ async def test_on_event_message_id_takes_precedence_over_correlation_id() -> Non
 
 
 @pytest.mark.asyncio
-async def test_on_event_invalid_message_id_falls_through_to_valid_correlation_id() -> None:
-    """Invalid message_id does not hide a valid correlation_id."""
+async def test_on_event_invalid_message_id_falls_through_to_valid_correlation_id() -> (
+    None
+):
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent(
-        '{"data": "test"}',
-        message_id="not-a-valid-uuid",
-        correlation_id=VALID_UUID_2,
+        '{"data": "test"}', message_id="not-a-valid-uuid", correlation_id=VALID_UUID_2
     )
 
     await consumer.on_event(MockPartitionContext(), event)
@@ -202,10 +215,11 @@ async def test_on_event_invalid_message_id_falls_through_to_valid_correlation_id
 
 @pytest.mark.asyncio
 async def test_on_event_invalid_uuid_falls_back_to_generated() -> None:
-    """Both IDs invalid → UUID5 fallback; original message_id preserved."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
-    event = MockEvent('{"data": "test"}', message_id="not-a-valid-uuid", sequence_number=42)
+    event = MockEvent(
+        '{"data": "test"}', message_id="not-a-valid-uuid", sequence_number=42
+    )
 
     await consumer.on_event(MockPartitionContext("1"), event)
 
@@ -219,9 +233,9 @@ async def test_on_event_invalid_uuid_falls_back_to_generated() -> None:
 # UUID assignment — AMQP non-string types
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_on_event_bytes_message_id_valid_uuid() -> None:
-    """bytes message_id containing a valid UUID string is accepted."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"data": "test"}', message_id=VALID_UUID_1.encode("utf-8"))
@@ -234,7 +248,6 @@ async def test_on_event_bytes_message_id_valid_uuid() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_uuid_object_message_id() -> None:
-    """uuid.UUID object as message_id is accepted directly."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     uuid_obj = uuid.UUID(VALID_UUID_1)
@@ -248,7 +261,6 @@ async def test_on_event_uuid_object_message_id() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_integer_message_id_falls_back() -> None:
-    """int (AMQP ulong) message_id falls back to UUID5; does not crash."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"data": "test"}', message_id=12345, sequence_number=7)
@@ -263,7 +275,6 @@ async def test_on_event_integer_message_id_falls_back() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_non_utf8_bytes_message_id_falls_back() -> None:
-    """Non-UTF-8 bytes message_id falls back to UUID5; normalised to hex."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     raw_bytes = b"\xff\xfe"
@@ -281,9 +292,9 @@ async def test_on_event_non_utf8_bytes_message_id_falls_back() -> None:
 # meta structure
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_on_event_produced_at_flat_on_meta() -> None:
-    """enqueued_time is surfaced as meta.produced_at (flat, not under meta.event)."""
     ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
@@ -298,7 +309,6 @@ async def test_on_event_produced_at_flat_on_meta() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_raw_string_body() -> None:
-    """Non-JSON body is stored as a raw string."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent("Hello World")
@@ -313,7 +323,6 @@ async def test_on_event_raw_string_body() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_unicode_error_does_not_enqueue() -> None:
-    """Unicode decode error on body means nothing is put in the queue."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
     event = MockEvent('{"message": "Hello World"}')
@@ -326,7 +335,6 @@ async def test_on_event_unicode_error_does_not_enqueue() -> None:
 
 @pytest.mark.asyncio
 async def test_on_event_none_event_does_not_enqueue() -> None:
-    """None event means nothing is put in the queue."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     consumer = _make_consumer(queue)
 
@@ -338,6 +346,7 @@ async def test_on_event_none_event_does_not_enqueue() -> None:
 # ---------------------------------------------------------------------------
 # Initialization
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_initialization() -> None:
@@ -371,12 +380,13 @@ async def test_azure_hub_consumer_defaults() -> None:
         consumer = AzureHubConsumer(queue, BASE_ARGS)
 
         assert consumer.consumer_group == "$Default"
-        assert consumer.starting_position == -1
+        assert consumer.starting_position == "@latest"
 
 
 # ---------------------------------------------------------------------------
 # start_receiving / end-to-end
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_start_receiving() -> None:
@@ -400,9 +410,9 @@ async def test_azure_hub_consumer_start_receiving() -> None:
 # Feedback
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_enabled_without_queue() -> None:
-    """ValueError is raised when feedback is enabled but no queue is provided."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     args = {**BASE_ARGS, "feedback": True}
 
@@ -414,7 +424,6 @@ async def test_azure_hub_consumer_feedback_enabled_without_queue() -> None:
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_enabled_with_queue() -> None:
-    """Consumer waits for feedback when enabled."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
     args = {**BASE_ARGS, "feedback": True, "eda_feedback_queue": feedback_queue}
@@ -433,7 +442,6 @@ async def test_azure_hub_consumer_feedback_enabled_with_queue() -> None:
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_timeout() -> None:
-    """TimeoutError is raised when feedback timeout is exceeded."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
     feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
     args = {
@@ -453,7 +461,6 @@ async def test_azure_hub_consumer_feedback_timeout() -> None:
 
 @pytest.mark.asyncio
 async def test_azure_hub_consumer_feedback_defaults() -> None:
-    """Feedback defaults are set correctly."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
 
     with patch(PATCH_CREDENTIAL):
@@ -461,3 +468,121 @@ async def test_azure_hub_consumer_feedback_defaults() -> None:
         assert consumer.feedback is False
         assert consumer.feedback_timeout == 120
         assert consumer.eda_feedback_queue is None
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_checkpoint_store_validation() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args = {**BASE_ARGS, "azure_storage_account_name": "mystorageaccount"}
+
+    with patch(PATCH_CREDENTIAL), pytest.raises(
+        ValueError, match="azure_checkpoint_container_name is required"
+    ):
+        AzureHubConsumer(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_checkpoint_store_init() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(
+        queue,
+        {
+            "azure_storage_account_name": "mystorageaccount",
+            "azure_checkpoint_container_name": "checkpoints",
+        },
+    )
+    assert consumer.storage_account_name == "mystorageaccount"
+    assert consumer.checkpoint_container_name == "checkpoints"
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_max_wait_time_default() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    assert consumer.max_wait_time == 60
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_max_wait_time_custom() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue, {"azure_max_wait_time": 30})
+    assert consumer.max_wait_time == 30
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_starting_position_numeric_string() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue, {"azure_starting_position": "-1"})
+    assert consumer.starting_position == -1
+    assert isinstance(consumer.starting_position, int)
+
+
+@pytest.mark.asyncio
+async def test_azure_hub_consumer_starting_position_string_preserved() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue, {"azure_starting_position": "@latest"})
+    assert consumer.starting_position == "@latest"
+    assert isinstance(consumer.starting_position, str)
+
+
+@pytest.mark.asyncio
+async def test_start_receiving_without_checkpoint_store() -> None:
+    mock_client = MockEventHubConsumerClient([])
+
+    with patch(PATCH_CREDENTIAL), patch(PATCH_CLIENT, return_value=mock_client):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        consumer = _make_consumer(queue, {"azure_starting_position": "@latest"})
+        await consumer.start_receiving()
+
+        assert mock_client.receive_kwargs["starting_position"] == "@latest"
+        assert mock_client.receive_kwargs["max_wait_time"] == 60
+
+
+@pytest.mark.asyncio
+async def test_start_receiving_with_checkpoint_store() -> None:
+    mock_client = MockEventHubConsumerClient([])
+
+    with patch(PATCH_CREDENTIAL), patch(
+        PATCH_CLIENT,
+        return_value=mock_client,
+    ) as mock_client_class, patch(PATCH_BLOB_STORE) as mock_blob_store:
+        mock_blob_store.return_value = mock_blob_store
+
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        consumer = _make_consumer(
+            queue,
+            {
+                "azure_storage_account_name": "mystorageaccount",
+                "azure_checkpoint_container_name": "checkpoints",
+            },
+        )
+
+        await consumer.start_receiving()
+
+        assert "starting_position" not in mock_client.receive_kwargs
+        assert mock_client.receive_kwargs["max_wait_time"] == 60
+        mock_blob_store.assert_called_once_with(
+            blob_account_url="https://mystorageaccount.blob.core.windows.net",
+            container_name="checkpoints",
+            credential=consumer.credential,
+        )
+        mock_client_class.assert_called_once_with(
+            fully_qualified_namespace="test.servicebus.windows.net",
+            eventhub_name="test_hub",
+            consumer_group="$Default",
+            credential=consumer.credential,
+            checkpoint_store=mock_blob_store,
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_receiving_no_storage_defaults() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    consumer = _make_consumer(queue)
+    assert consumer.storage_account_name is None
+    assert consumer.checkpoint_container_name is None

--- a/tests/unit/event_source/test_azure_service_bus.py
+++ b/tests/unit/event_source/test_azure_service_bus.py
@@ -1,12 +1,13 @@
 import asyncio
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Type
+from typing import Any, Self
 from unittest.mock import patch
 
 import pytest
 
 from extensions.eda.plugins.event_source.azure_service_bus import (
+    _create_service_bus_client,
     _uuid_warning,
     receive_events,
 )
@@ -15,7 +16,10 @@ VALID_UUID_1 = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
 VALID_UUID_2 = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
 QUEUE_NAME = "queue"
 
-PATCH_TARGET = (
+PATCH_CREATE_CLIENT = (
+    "extensions.eda.plugins.event_source.azure_service_bus._create_service_bus_client"
+)
+PATCH_CONN_STR = (
     "extensions.eda.plugins.event_source.azure_service_bus"
     ".ServiceBusClient.from_connection_string"
 )
@@ -58,14 +62,14 @@ class MockReceiver:
     def __init__(self, msgs: list[MockMsg]) -> None:
         self._msgs = msgs
 
-    async def __aenter__(self) -> "MockReceiver":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Any,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
     ) -> None:
         pass
 
@@ -75,23 +79,35 @@ class MockReceiver:
     async def complete_message(self, msg: MockMsg) -> None:
         pass
 
+    async def dead_letter_message(self, msg: MockMsg, **kwargs: Any) -> None:
+        pass
+
 
 class MockServiceBusClient:
     def __init__(self, msgs: list[MockMsg]) -> None:
         self._msgs = msgs
 
-    async def __aenter__(self) -> "MockServiceBusClient":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc: Optional[BaseException],
-        tb: Any,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
     ) -> None:
         pass
 
-    def get_queue_receiver(self, queue_name: Optional[str] = None) -> MockReceiver:
+    def get_queue_receiver(self, queue_name: str | None = None) -> MockReceiver:
+        return MockReceiver(self._msgs)
+
+    def get_subscription_receiver(
+        self,
+        topic_name: str,
+        subscription_name: str,
+    ) -> MockReceiver:
+        self.received_topic = topic_name
+        self.received_subscription = subscription_name
         return MockReceiver(self._msgs)
 
 
@@ -102,12 +118,14 @@ def reset_uuid_warning():
     _uuid_warning["emitted"] = False
 
 
-async def _run(msgs: list[MockMsg], extra_args: Dict[str, Any] | None = None) -> asyncio.Queue:
+async def _run(
+    msgs: list[MockMsg], extra_args: dict[str, Any] | None = None
+) -> asyncio.Queue:
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {"conn_str": "fake", "queue_name": QUEUE_NAME}
+    args: dict[str, Any] = {"conn_str": "fake", "queue_name": QUEUE_NAME}
     if extra_args:
         args.update(extra_args)
-    with patch(PATCH_TARGET, return_value=MockServiceBusClient(msgs)):
+    with patch(PATCH_CREATE_CLIENT, return_value=MockServiceBusClient(msgs)):
         await receive_events(queue, args)
     return queue
 
@@ -120,9 +138,9 @@ def _expected_fallback_uuid(sequence_number: int = 0) -> str:
 # UUID assignment
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_receive_events_valid_uuid_message_id() -> None:
-    """Valid UUID message_id is used directly as meta.uuid."""
     msg = MockMsg(VALID_UUID_1, '{"data": "test"}')
 
     queue = await _run([msg])
@@ -134,7 +152,6 @@ async def test_receive_events_valid_uuid_message_id() -> None:
 
 @pytest.mark.asyncio
 async def test_receive_events_non_uuid_message_id_falls_back() -> None:
-    """Non-UUID message_ids fall back to UUID5 seeded on queue_name:sequence_number."""
     msg1 = MockMsg(1, "Hello World", sequence_number=0)
     msg2 = MockMsg(2, '{"Say": "Hello World"}', sequence_number=1)
 
@@ -155,7 +172,6 @@ async def test_receive_events_non_uuid_message_id_falls_back() -> None:
 
 @pytest.mark.asyncio
 async def test_receive_events_invalid_uuid_falls_back() -> None:
-    """Invalid UUID message_id falls back to UUID5 of queue_name:sequence_number; original preserved."""
     msg = MockMsg("not-a-valid-uuid", '{"data": "test"}', sequence_number=42)
 
     queue = await _run([msg])
@@ -167,7 +183,6 @@ async def test_receive_events_invalid_uuid_falls_back() -> None:
 
 @pytest.mark.asyncio
 async def test_receive_events_message_id_always_preserved() -> None:
-    """meta.message_id is present regardless of whether the UUID was valid."""
     msg_valid = MockMsg(VALID_UUID_1, '{"a": 1}')
     msg_invalid = MockMsg("not-a-uuid", '{"b": 2}')
 
@@ -182,16 +197,14 @@ async def test_receive_events_message_id_always_preserved() -> None:
 
 @pytest.mark.asyncio
 async def test_receive_events_uuid5_seed_includes_queue_name() -> None:
-    """UUID5 fallback seed includes queue_name, so the same sequence_number on different
-    queues produces distinct UUIDs."""
     msg = MockMsg("not-a-uuid", '{"data": "test"}', sequence_number=0)
 
     queue_a: asyncio.Queue[Any] = asyncio.Queue()
     queue_b: asyncio.Queue[Any] = asyncio.Queue()
 
-    with patch(PATCH_TARGET, return_value=MockServiceBusClient([msg])):
+    with patch(PATCH_CREATE_CLIENT, return_value=MockServiceBusClient([msg])):
         await receive_events(queue_a, {"conn_str": "fake", "queue_name": "queue-a"})
-    with patch(PATCH_TARGET, return_value=MockServiceBusClient([msg])):
+    with patch(PATCH_CREATE_CLIENT, return_value=MockServiceBusClient([msg])):
         await receive_events(queue_b, {"conn_str": "fake", "queue_name": "queue-b"})
 
     result_a = await queue_a.get()
@@ -204,9 +217,9 @@ async def test_receive_events_uuid5_seed_includes_queue_name() -> None:
 # meta structure
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_receive_events_produced_at() -> None:
-    """enqueued_time_utc is surfaced as meta.produced_at (flat on meta)."""
     ts = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
     msg = MockMsg(VALID_UUID_2, '{"x": 1}', enqueued_time_utc=ts)
 
@@ -221,23 +234,24 @@ async def test_receive_events_produced_at() -> None:
 # Feedback
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_receive_events_feedback_enabled_without_queue() -> None:
-    """ValueError is raised when feedback is enabled but no queue is provided."""
     queue: asyncio.Queue[Any] = asyncio.Queue()
-    args: Dict[str, Any] = {
+    args: dict[str, Any] = {
         "conn_str": "fake",
         "queue_name": QUEUE_NAME,
         "feedback": True,
     }
 
-    with pytest.raises(ValueError, match="feedback: true was set but no feedback queue"):
+    with pytest.raises(
+        ValueError, match="feedback: true was set but no feedback queue"
+    ):
         await receive_events(queue, args)
 
 
 @pytest.mark.asyncio
 async def test_receive_events_feedback_enabled_with_queue() -> None:
-    """Consumer waits for feedback when enabled."""
     msg = MockMsg(VALID_UUID_1, '{"message": "Test"}')
     feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
     await feedback_queue.put("feedback_received")
@@ -251,12 +265,214 @@ async def test_receive_events_feedback_enabled_with_queue() -> None:
 
 @pytest.mark.asyncio
 async def test_receive_events_feedback_timeout() -> None:
-    """TimeoutError is raised when feedback timeout is exceeded."""
     msg = MockMsg(VALID_UUID_1, '{"message": "Test"}')
 
     with pytest.raises(asyncio.TimeoutError):
         feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
         await _run(
             [msg],
-            {"feedback": True, "eda_feedback_queue": feedback_queue, "feedback_timeout": 0.1},
+            {
+                "feedback": True,
+                "eda_feedback_queue": feedback_queue,
+                "feedback_timeout": 0.1,
+            },
         )
+
+
+# ---------------------------------------------------------------------------
+# _create_service_bus_client
+# ---------------------------------------------------------------------------
+
+
+def test_create_client_with_connection_string() -> None:
+    args: dict[str, Any] = {"conn_str": "Endpoint=sb://fake.servicebus.windows.net/"}
+    with patch(PATCH_CONN_STR) as mock_from_conn:
+        mock_from_conn.return_value = "mock_client"
+        result = _create_service_bus_client(args)
+        mock_from_conn.assert_called_once_with(
+            conn_str="Endpoint=sb://fake.servicebus.windows.net/",
+            logging_enable=True,
+        )
+        assert result == "mock_client"
+
+
+def test_create_client_with_service_principal() -> None:
+    args: dict[str, Any] = {
+        "azure_tenant_id": "tenant",
+        "azure_client_id": "client",
+        "azure_client_secret": "secret",
+        "azure_namespace": "mybus.servicebus.windows.net",
+    }
+    with patch(
+        "extensions.eda.plugins.event_source.azure_service_bus.ClientSecretCredential"
+    ) as mock_cred, patch(
+        "extensions.eda.plugins.event_source.azure_service_bus.ServiceBusClient"
+    ) as mock_client_class:
+        mock_cred.return_value = "mock_credential"
+        mock_client_class.return_value = "mock_client"
+
+        result = _create_service_bus_client(args)
+
+        mock_cred.assert_called_once_with(
+            tenant_id="tenant",
+            client_id="client",
+            client_secret="secret",
+        )
+        mock_client_class.assert_called_once_with(
+            fully_qualified_namespace="mybus.servicebus.windows.net",
+            credential="mock_credential",
+            logging_enable=True,
+        )
+        assert result == "mock_client"
+
+
+def test_create_client_no_credentials() -> None:
+    with pytest.raises(ValueError, match="Either 'conn_str' OR"):
+        _create_service_bus_client({})
+
+
+def test_create_client_partial_service_principal() -> None:
+    args: dict[str, Any] = {
+        "azure_tenant_id": "tenant",
+        "azure_client_id": "client",
+    }
+    with pytest.raises(ValueError, match="Either 'conn_str' OR"):
+        _create_service_bus_client(args)
+
+
+def test_create_client_logging_disable() -> None:
+    args: dict[str, Any] = {"conn_str": "fake", "logging_enable": False}
+    with patch(PATCH_CONN_STR) as mock_from_conn:
+        _create_service_bus_client(args)
+        mock_from_conn.assert_called_once_with(conn_str="fake", logging_enable=False)
+
+
+# ---------------------------------------------------------------------------
+# Queue vs topic/subscription validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_events_both_queue_and_topic() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: dict[str, Any] = {
+        "conn_str": "fake",
+        "queue_name": "my-queue",
+        "azure_topic_name": "my-topic",
+        "azure_subscription_name": "my-sub",
+    }
+
+    with pytest.raises(
+        ValueError, match="Cannot specify both queue_name and azure_topic_name"
+    ):
+        await receive_events(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_receive_events_neither_queue_nor_topic() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: dict[str, Any] = {"conn_str": "fake"}
+
+    with pytest.raises(ValueError, match="Either queue_name OR"):
+        await receive_events(queue, args)
+
+
+@pytest.mark.asyncio
+async def test_receive_events_topic_without_subscription() -> None:
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    args: dict[str, Any] = {
+        "conn_str": "fake",
+        "azure_topic_name": "my-topic",
+    }
+
+    with pytest.raises(ValueError, match="Either queue_name OR"):
+        await receive_events(queue, args)
+
+
+# ---------------------------------------------------------------------------
+# Topic/subscription receiver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_events_with_topic_subscription() -> None:
+    msg1 = MockMsg(VALID_UUID_1, '{"key": "value"}')
+    mock_sb_client = MockServiceBusClient([msg1])
+
+    with patch(PATCH_CREATE_CLIENT, return_value=mock_sb_client):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: dict[str, Any] = {
+            "conn_str": "fake",
+            "azure_topic_name": "my-topic",
+            "azure_subscription_name": "my-sub",
+        }
+
+        await receive_events(queue, args)
+
+        result = await queue.get()
+        assert result["body"] == {"key": "value"}
+        assert mock_sb_client.received_topic == "my-topic"
+        assert mock_sb_client.received_subscription == "my-sub"
+
+
+# ---------------------------------------------------------------------------
+# Service principal with receive_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_events_with_service_principal() -> None:
+    msg1 = MockMsg(VALID_UUID_1, '{"sp": "test"}')
+    mock_sb_client = MockServiceBusClient([msg1])
+
+    with patch(PATCH_CREATE_CLIENT, return_value=mock_sb_client) as mock_create:
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: dict[str, Any] = {
+            "azure_tenant_id": "tenant",
+            "azure_client_id": "client",
+            "azure_client_secret": "secret",
+            "azure_namespace": "mybus.servicebus.windows.net",
+            "queue_name": "my-queue",
+        }
+
+        await receive_events(queue, args)
+
+        mock_create.assert_called_once_with(args)
+        result = await queue.get()
+        assert result["body"] == {"sp": "test"}
+
+
+# ---------------------------------------------------------------------------
+# Dead-letter on feedback timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_events_dead_letter_on_feedback_timeout() -> None:
+    msg1 = MockMsg(VALID_UUID_1, '{"msg": "test"}')
+    dead_lettered: list[MockMsg] = []
+
+    class DLQMockReceiver(MockReceiver):
+        async def dead_letter_message(self, msg: MockMsg, **kwargs: Any) -> None:
+            dead_lettered.append(msg)
+
+    class DLQMockServiceBusClient(MockServiceBusClient):
+        def get_queue_receiver(self, queue_name: str | None = None) -> DLQMockReceiver:
+            return DLQMockReceiver(self._msgs)
+
+    with patch(PATCH_CREATE_CLIENT, return_value=DLQMockServiceBusClient([msg1])):
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        feedback_queue: asyncio.Queue[Any] = asyncio.Queue()
+        args: dict[str, Any] = {
+            "conn_str": "fake",
+            "queue_name": "queue",
+            "feedback": True,
+            "eda_feedback_queue": feedback_queue,
+            "feedback_timeout": 0.1,
+        }
+
+        with pytest.raises(asyncio.TimeoutError):
+            await receive_events(queue, args)
+
+        assert len(dead_lettered) >= 1
+        assert all(m.message_id == VALID_UUID_1 for m in dead_lettered)

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,6 @@
 azure-servicebus
 azure-eventhub
+azure-eventhub-checkpointstoreblob-aio
 aiohttp
 pytest-asyncio
 azure-identity==1.25.2


### PR DESCRIPTION
##### SUMMARY
Enhance EDA Source Plugins
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
* azure.azcollection.azure_service_bus
* azure.azcollection.azure_event_hub

**Azure Event Hub:**
- Add persistent checkpoint storage via Azure Blob Storage (azure_storage_account_name, azure_checkpoint_container_name)
- When checkpoint store is configured, starting_position is omitted from receive() to let the SDK correctly resume from checkpoints
- Add azure_max_wait_time parameter for load balancing interval control
- Change default starting_position from "-1" to "@latest"
- Coerce numeric starting_position strings to int for backward compatibility with existing rulebooks passing "-1" or other offsets

**Azure Service Bus:**
- Add service principal authentication (azure_tenant_id, azure_client_id, azure_client_secret, azure_namespace) as an alternative to conn_str
- Add topic/subscription support via topic_name and subscription_name
- Add dead-letter handling on feedback timeout and processing errors
- Validate mutually exclusive queue vs topic/subscription configuration

New Python package dependencies:
- azure-eventhub-checkpointstoreblob-aio (for persistent checkpoint storage)
- azure-identity (for service principal authentication via ClientSecretCredential)

Tests:
- Add tests for checkpoint store validation, creation, and receive behavior
- Add tests for starting_position type coercion (numeric vs string)
- Add tests for max_wait_time configuration
- Add tests for _create_service_bus_client with both auth methods
- Add tests for topic/subscription receiver and validation
- Add tests for dead-letter on feedback timeout
- Update existing tests for new defaults and refactored internals