### PR TITLE
Fix #1931: Query Graph beta endpoint for `adgroup` members so `servicePrincipals` are returned

### DIFF
--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -567,21 +567,10 @@ class AzureRMADGroup(AzureRMModuleBase):
         await self._client.groups.by_group_id(group_id).members.by_directory_object_id(member_id).ref.delete()
 
     async def get_group_owners(self, group_id):
-        request_configuration = GroupsRequestBuilder.GroupsRequestBuilderGetRequestConfiguration(
-            query_parameters=GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters(
-                count=True,
-            ),
-        )
-        response = await self._client.groups.by_group_id(group_id).owners.get(request_configuration=request_configuration)
-        groups = []
-        if response:
-            groups += response.value
-        while response is not None and response.odata_next_link is not None:
-            response = await self._client.groups.by_group_id(group_id).owners.with_url(response.odata_next_link).get(
-                request_configuration=request_configuration)
-            if response:
-                groups += response.value
-        return groups
+        '''Query beta /groups/{id}/owners; v1.0 omits servicePrincipal owners (documented).'''
+        url = "{0}/groups/{1}/owners".format(BETA_GRAPH_BASE_URL, group_id)
+        return await self._collect_paged_beta(
+            self._client.groups.by_group_id(group_id).owners, url)
 
     async def add_group_owner(self, group_id, obj_id):
         request_body = ReferenceCreate(

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -242,6 +242,7 @@ BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
 
 try:
     import asyncio
+    from kiota_abstractions.base_request_configuration import RequestConfiguration
     from msgraph.generated.groups.groups_request_builder import GroupsRequestBuilder
     from msgraph.generated.models.group import Group
     from msgraph.generated.models.reference_create import ReferenceCreate
@@ -539,21 +540,30 @@ class AzureRMADGroup(AzureRMModuleBase):
             self._client.groups.by_group_id(group_id).members, url)
 
     async def get_transitive_group_members(self, group_id, filters=None):
-        '''Query beta /groups/{id}/transitiveMembers; same v1.0 omission applies.'''
+        '''Query beta /groups/{id}/transitiveMembers; same v1.0 omission applies.
+
+        Graph classifies filtering on /transitiveMembers as an advanced query and
+        requires the ConsistencyLevel: eventual header; without it Graph returns 400.
+        '''
         url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
+        request_configuration = RequestConfiguration()
+        request_configuration.headers.try_add("ConsistencyLevel", "eventual")
         return await self._collect_paged_beta(
-            self._client.groups.by_group_id(group_id).transitive_members, url)
+            self._client.groups.by_group_id(group_id).transitive_members, url, request_configuration)
 
-    async def _collect_paged_beta(self, request_builder, initial_url):
+    async def _collect_paged_beta(self, request_builder, initial_url, request_configuration=None):
         '''Follow odata_next_link starting from a beta URL; SDK adapter/auth is preserved.'''
-        response = await request_builder.with_url(initial_url).get()
+        kwargs = {}
+        if request_configuration is not None:
+            kwargs["request_configuration"] = request_configuration
+        response = await request_builder.with_url(initial_url).get(**kwargs)
         items = []
         if response and response.value:
             items += response.value
         while response is not None and response.odata_next_link is not None:
-            response = await request_builder.with_url(response.odata_next_link).get()
+            response = await request_builder.with_url(response.odata_next_link).get(**kwargs)
             if response and response.value:
                 items += response.value
         return items

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -63,10 +63,11 @@ options:
             - The azure ad objects asserted to not be owners of the group.
         type: list
         elements: str
-    raw_membership:
+    include_transitive_members:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects before return. \
-             This argument disables those transformations.
+            - When true, the returned I(group_members) list contains transitive members
+              (nested-group expansion). When false, only direct members are returned.
+            - Add and remove operations always target direct membership regardless of this flag.
         default: false
         type: bool
     description:
@@ -115,14 +116,14 @@ EXAMPLES = '''
       - "{{ ad_object_1_object_id }}"
       - "{{ ad_object_2_object_id }}"
 
-- name: Ensure Users are Members of a Group using object_id. Specify the group_membership return should be unfiltered
+- name: Ensure Users are Members of a Group and expose transitive members in the return
   azure_rm_adgroup:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     state: 'present'
     present_members:
       - "{{ ad_object_1_object_id }}"
       - "{{ ad_object_2_object_id }}"
-    raw_membership: true
+    include_transitive_members: true
 
 - name: Ensure Users are not Members of a Group using display_name and mail_nickname
   azure_rm_adgroup:
@@ -218,7 +219,10 @@ group_owners:
     type: list
 group_members:
     description:
-        - The members of the group. If raw_membership is false, this contains the transitive members property. Otherwise, it contains the members property.
+        - The members of the group. Contains direct members by default, or transitive members
+          when C(include_transitive_members=true). Service Principals and Managed Identities are
+          included (the module queries the Microsoft Graph beta endpoint to work around a
+          documented v1.0 limitation where service principals are omitted from group member listings).
     returned: always
     type: list
 description:
@@ -231,13 +235,12 @@ description:
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
 
+BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
+
 try:
     import asyncio
     from msgraph.generated.groups.groups_request_builder import GroupsRequestBuilder
     from msgraph.generated.models.group import Group
-    from msgraph.generated.groups.item.transitive_members.transitive_members_request_builder import \
-        TransitiveMembersRequestBuilder
-    from msgraph.generated.groups.item.group_item_request_builder import GroupItemRequestBuilder
     from msgraph.generated.models.reference_create import ReferenceCreate
 except ImportError:
     # This is handled in azure_rm_common
@@ -255,7 +258,7 @@ class AzureRMADGroup(AzureRMModuleBase):
             present_owners=dict(type='list', elements='str'),
             absent_members=dict(type='list', elements='str'),
             absent_owners=dict(type='list', elements='str'),
-            raw_membership=dict(type='bool', default=False),
+            include_transitive_members=dict(type='bool', default=False),
             description=dict(type='str'),
             state=dict(
                 type='str',
@@ -274,7 +277,7 @@ class AzureRMADGroup(AzureRMModuleBase):
         self.state = None
         self.results = dict(changed=False)
         self._client = None
-        self.raw_membership = False
+        self.include_transitive_members = False
 
         super(AzureRMADGroup, self).__init__(derived_arg_spec=self.module_arg_spec,
                                              supports_check_mode=False,
@@ -358,7 +361,7 @@ class AzureRMADGroup(AzureRMModuleBase):
                 self.results.update(self.set_results(ad_groups[0]))
 
         except Exception as e:
-            self.fail(e)
+            self.fail(str(e))
         return self.results
 
     def update_members(self, group_id):
@@ -517,52 +520,38 @@ class AzureRMADGroup(AzureRMModuleBase):
         return groups
 
     async def get_group_members(self, group_id, filters=None):
-        if self.raw_membership:
-            return await self.get_raw_group_members(group_id, filters)
-        else:
+        '''Return direct or transitive members; add/remove ops always target direct membership.'''
+        if self.include_transitive_members:
             return await self.get_transitive_group_members(group_id, filters)
+        return await self.get_direct_group_members(group_id, filters)
+
+    async def get_direct_group_members(self, group_id, filters=None):
+        '''Query beta /groups/{id}/members. v1.0 omits servicePrincipal objects (documented).'''
+        url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
+        if filters:
+            url += "?$filter={0}".format(filters)
+        return await self._collect_paged_beta(
+            self._client.groups.by_group_id(group_id).members, url)
 
     async def get_transitive_group_members(self, group_id, filters=None):
-        request_configuration = TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetRequestConfiguration(
-            query_parameters=TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetQueryParameters(
-                count=True,
-            ),
-        )
+        '''Query beta /groups/{id}/transitiveMembers; same v1.0 omission applies.'''
+        url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            request_configuration.query_parameters.filter = filters
-        response = await self._client.groups.by_group_id(group_id).transitive_members.get(
-            request_configuration=request_configuration)
+            url += "?$filter={0}".format(filters)
+        return await self._collect_paged_beta(
+            self._client.groups.by_group_id(group_id).transitive_members, url)
 
-        groups = []
-        if response:
-            groups += response.value
+    async def _collect_paged_beta(self, request_builder, initial_url):
+        '''Follow odata_next_link starting from a beta URL; SDK adapter/auth is preserved.'''
+        response = await request_builder.with_url(initial_url).get()
+        items = []
+        if response and response.value:
+            items += response.value
         while response is not None and response.odata_next_link is not None:
-            response = await self._client.groups.by_group_id(group_id).transitive_members.with_url(response.odata_next_link).get(
-                request_configuration=request_configuration)
-            if response:
-                groups += response.value
-        return groups
-
-    async def get_raw_group_members(self, group_id, filters=None):
-        request_configuration = GroupItemRequestBuilder.GroupItemRequestBuilderGetRequestConfiguration(
-            query_parameters=GroupItemRequestBuilder.GroupItemRequestBuilderGetQueryParameters(
-                # this ensures service principals are returned
-                # see https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
-                # expand=["members"]
-            ),
-        )
-        if filters:
-            request_configuration.query_parameters.filter = filters
-        response = await self._client.groups.by_group_id(group_id).members.get(request_configuration=request_configuration)
-        groups = []
-        if response:
-            groups += response.value
-        while response is not None and response.odata_next_link is not None:
-            response = await self._client.groups.by_group_id(group_id).members.with_url(response.odata_next_link).get(
-                request_configuration=request_configuration)
-            if response:
-                groups += response.value
-        return groups
+            response = await request_builder.with_url(response.odata_next_link).get()
+            if response and response.value:
+                items += response.value
+        return items
 
     async def add_group_member(self, group_id, obj_id):
         request_body = ReferenceCreate(

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -236,6 +236,7 @@ description:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
+from urllib.parse import quote
 
 BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
 
@@ -533,7 +534,7 @@ class AzureRMADGroup(AzureRMModuleBase):
         '''Query beta /groups/{id}/members. v1.0 omits servicePrincipal objects (documented).'''
         url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            url += "?$filter={0}".format(filters)
+            url += "?$filter={0}".format(quote(filters, safe=""))
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).members, url)
 
@@ -541,7 +542,7 @@ class AzureRMADGroup(AzureRMModuleBase):
         '''Query beta /groups/{id}/transitiveMembers; same v1.0 omission applies.'''
         url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            url += "?$filter={0}".format(filters)
+            url += "?$filter={0}".format(quote(filters, safe=""))
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).transitive_members, url)
 
@@ -574,7 +575,7 @@ class AzureRMADGroup(AzureRMModuleBase):
 
     async def add_group_owner(self, group_id, obj_id):
         request_body = ReferenceCreate(
-            odata_id="https://graph.microsoft.com/v1.0/users/{0}".format(obj_id),
+            odata_id="https://graph.microsoft.com/v1.0/directoryObjects/{0}".format(obj_id),
         )
         await self._client.groups.by_group_id(group_id).owners.ref.post(body=request_body)
 

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -236,9 +236,7 @@ description:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
-from urllib.parse import quote
-
-BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
+from urllib.parse import quote, urlparse
 
 try:
     import asyncio
@@ -525,6 +523,15 @@ class AzureRMADGroup(AzureRMModuleBase):
                 groups += response.value
         return groups
 
+    def _graph_base(self, version):
+        '''Return the Graph base URL for the tenant's cloud (e.g. https://graph.microsoft.us/beta).
+
+        Derived from the SDK request adapter so sovereign clouds (US Gov, China, Germany)
+        receive matching @odata.id references. Cross-cloud references are not supported by Graph.
+        '''
+        parsed = urlparse(self._client.request_adapter.base_url)
+        return "{0}://{1}/{2}".format(parsed.scheme, parsed.netloc, version)
+
     async def get_group_members(self, group_id, filters=None):
         '''Return direct or transitive members; add/remove ops always target direct membership.'''
         if self.include_transitive_members:
@@ -533,7 +540,7 @@ class AzureRMADGroup(AzureRMModuleBase):
 
     async def get_direct_group_members(self, group_id, filters=None):
         '''Query beta /groups/{id}/members. v1.0 omits servicePrincipal objects (documented).'''
-        url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
+        url = "{0}/groups/{1}/members".format(self._graph_base("beta"), group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
         return await self._collect_paged_beta(
@@ -545,7 +552,7 @@ class AzureRMADGroup(AzureRMModuleBase):
         Graph classifies filtering on /transitiveMembers as an advanced query and
         requires the ConsistencyLevel: eventual header; without it Graph returns 400.
         '''
-        url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
+        url = "{0}/groups/{1}/transitiveMembers".format(self._graph_base("beta"), group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
         request_configuration = RequestConfiguration()
@@ -570,7 +577,7 @@ class AzureRMADGroup(AzureRMModuleBase):
 
     async def add_group_member(self, group_id, obj_id):
         request_body = ReferenceCreate(
-            odata_id="https://graph.microsoft.com/v1.0/directoryObjects/{0}".format(obj_id),
+            odata_id="{0}/directoryObjects/{1}".format(self._graph_base("v1.0"), obj_id),
         )
         await self._client.groups.by_group_id(group_id).members.ref.post(body=request_body)
 
@@ -579,13 +586,13 @@ class AzureRMADGroup(AzureRMModuleBase):
 
     async def get_group_owners(self, group_id):
         '''Query beta /groups/{id}/owners; v1.0 omits servicePrincipal owners (documented).'''
-        url = "{0}/groups/{1}/owners".format(BETA_GRAPH_BASE_URL, group_id)
+        url = "{0}/groups/{1}/owners".format(self._graph_base("beta"), group_id)
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).owners, url)
 
     async def add_group_owner(self, group_id, obj_id):
         request_body = ReferenceCreate(
-            odata_id="https://graph.microsoft.com/v1.0/directoryObjects/{0}".format(obj_id),
+            odata_id="{0}/directoryObjects/{1}".format(self._graph_base("v1.0"), obj_id),
         )
         await self._client.groups.by_group_id(group_id).owners.ref.post(body=request_body)
 

--- a/plugins/modules/azure_rm_adgroup.py
+++ b/plugins/modules/azure_rm_adgroup.py
@@ -68,6 +68,8 @@ options:
             - When true, the returned I(group_members) list contains transitive members
               (nested-group expansion). When false, only direct members are returned.
             - Add and remove operations always target direct membership regardless of this flag.
+            - Note that the default membership view is direct members. In prior versions the
+              default view was transitive; set this option to C(true) to preserve that behavior.
         default: false
         type: bool
     description:
@@ -368,7 +370,9 @@ class AzureRMADGroup(AzureRMModuleBase):
         current_members = []
 
         if self.present_members or self.absent_members:
-            ret = asyncio.get_event_loop().run_until_complete(self.get_group_members(group_id))
+            # Always diff against direct members: add/remove target direct membership,
+            # regardless of include_transitive_members (which only shapes the return payload).
+            ret = asyncio.get_event_loop().run_until_complete(self.get_direct_group_members(group_id))
             current_members = [object.id for object in ret]
 
         if self.present_members:

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -360,24 +360,11 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         return groups
 
     async def get_group_owners(self, group_id):
-        request_configuration = GroupsRequestBuilder.GroupsRequestBuilderGetRequestConfiguration(
-            query_parameters=GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters(
-                count=True,
-                select=['id', 'displayName', 'userPrincipalName', 'mailNickname', 'mail', 'accountEnabled', 'userType',
-                        'appId', 'appRoleAssignmentRequired']
-
-            ),
-        )
-        response = await self._client.groups.by_group_id(group_id).owners.get(request_configuration=request_configuration)
-        groups = []
-        if response:
-            groups += response.value
-        while response is not None and response.odata_next_link is not None:
-            response = await self._client.groups.by_group_id(group_id).owners.with_url(response.odata_next_link).get(
-                request_configuration=request_configuration)
-            if response:
-                groups += response.value
-        return groups
+        '''Query beta /groups/{id}/owners; v1.0 omits servicePrincipal owners (documented).'''
+        select = "id,displayName,userPrincipalName,mailNickname,mail,accountEnabled,userType,appId,appRoleAssignmentRequired"
+        url = "{0}/groups/{1}/owners?$select={2}".format(BETA_GRAPH_BASE_URL, group_id, select)
+        return await self._collect_paged_beta(
+            self._client.groups.by_group_id(group_id).owners, url)
 
     async def get_group_members(self, group_id, filters=None):
         '''Return direct or transitive members via the Graph beta endpoint.'''

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -55,10 +55,10 @@ options:
             - Indicate whether the groups in which a groups is a member should be returned with the returned groups.
         default: False
         type: bool
-    raw_membership:
+    include_transitive_members:
         description:
-            - By default the group_members return property is flattened and partially filtered of non-User objects before return.\
-              This argument disables those transformations.
+            - When true, I(group_members) contains transitive members (nested-group expansion).
+            - When false, only direct members are returned.
         default: false
         type: bool
     all:
@@ -90,12 +90,12 @@ EXAMPLES = '''
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true
     return_group_members: true
-- name: Return a specific group using object_id and return the owners and members of the group. Return service principals and nested groups.
+- name: Return a specific group using object_id and return transitive membership (nested-group expansion)
   azure_rm_adgroup_info:
     object_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     return_owners: true
     return_group_members: true
-    raw_membership: true
+    include_transitive_members: true
 
 - name: Return a specific group using object_id and return the groups the group is a member of
   azure_rm_adgroup_info:
@@ -165,7 +165,10 @@ group_owners:
     type: list
 group_members:
     description:
-        - The members of the group. If raw_membership is set, this field may contain non-user objects (groups, service principals, etc)
+        - The members of the group. Contains direct members by default, or transitive members
+          when C(include_transitive_members=true). Service Principals and Managed Identities are
+          included (the module queries the Microsoft Graph beta endpoint to work around a
+          documented v1.0 limitation where service principals are omitted).
     returned: always
     type: list
 description:
@@ -178,14 +181,13 @@ description:
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
 
+BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
+
 try:
     import asyncio
     from msgraph.generated.groups.groups_request_builder import GroupsRequestBuilder
-    from msgraph.generated.groups.item.transitive_members.transitive_members_request_builder import \
-        TransitiveMembersRequestBuilder
     from msgraph.generated.groups.item.get_member_groups.get_member_groups_post_request_body import \
         GetMemberGroupsPostRequestBody
-    from msgraph.generated.groups.item.group_item_request_builder import GroupItemRequestBuilder
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -203,7 +205,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
             return_owners=dict(type='bool', default=False),
             return_group_members=dict(type='bool', default=False),
             return_member_groups=dict(type='bool', default=False),
-            raw_membership=dict(type='bool', default=False),
+            include_transitive_members=dict(type='bool', default=False),
             all=dict(type='bool', default=False),
         )
 
@@ -215,7 +217,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         self.return_owners = False
         self.return_group_members = False
         self.return_member_groups = False
-        self.raw_membership = False
+        self.include_transitive_members = False
         self.all = False
 
         self.results = dict(changed=False)
@@ -376,57 +378,41 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         return groups
 
     async def get_group_members(self, group_id, filters=None):
-        if self.raw_membership:
-            return await self.get_raw_group_members(group_id, filters)
-        else:
+        '''Return direct or transitive members via the Graph beta endpoint.'''
+        if self.include_transitive_members:
             return await self.get_transitive_group_members(group_id, filters)
+        return await self.get_direct_group_members(group_id, filters)
 
     async def get_transitive_group_members(self, group_id, filters=None):
-        request_configuration = TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetRequestConfiguration(
-            query_parameters=TransitiveMembersRequestBuilder.TransitiveMembersRequestBuilderGetQueryParameters(
-                count=True,
-            ),
-        )
+        '''Query beta /groups/{id}/transitiveMembers; v1.0 omits servicePrincipal objects.'''
+        url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            request_configuration.query_parameters.filter = filters
+            url += "?$filter={0}".format(filters)
         try:
-            response = await self._client.groups.by_group_id(group_id).transitive_members.get(
-                request_configuration=request_configuration)
-            groups = []
-
-            if response:
-                groups += response.value
-            while response is not None and response.odata_next_link is not None:
-                response = await self._client.groups.by_group_id(group_id).transitive_members.with_url(response.odata_next_link).get(
-                    request_configuration=request_configuration)
-                if response:
-                    groups += response.value
-            return groups
+            return await self._collect_paged_beta(
+                self._client.groups.by_group_id(group_id).transitive_members, url)
         except Exception:
             return
 
-    async def get_raw_group_members(self, group_id, filters=None):
-        request_configuration = GroupItemRequestBuilder.GroupItemRequestBuilderGetRequestConfiguration(
-            query_parameters=GroupItemRequestBuilder.GroupItemRequestBuilderGetQueryParameters(
-                # this ensures service principals are returned
-                # see https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
-                # expand=["members"]
-            ),
-        )
+    async def get_direct_group_members(self, group_id, filters=None):
+        '''Query beta /groups/{id}/members; v1.0 omits servicePrincipal objects.'''
+        url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            request_configuration.query_parameters.filter = filters
-        response = await self._client.groups.by_group_id(group_id).members.get(
-            request_configuration=request_configuration)
-        groups = []
+            url += "?$filter={0}".format(filters)
+        return await self._collect_paged_beta(
+            self._client.groups.by_group_id(group_id).members, url)
 
-        if response:
-            groups += response.value
+    async def _collect_paged_beta(self, request_builder, initial_url):
+        '''Follow odata_next_link starting from a beta URL; SDK adapter/auth is preserved.'''
+        response = await request_builder.with_url(initial_url).get()
+        items = []
+        if response and response.value:
+            items += response.value
         while response is not None and response.odata_next_link is not None:
-            response = await self._client.groups.by_group_id(group_id).members.with_url(response.odata_next_link).get(
-                request_configuration=request_configuration)
-            if response:
-                groups += response.value
-        return groups
+            response = await request_builder.with_url(response.odata_next_link).get()
+            if response and response.value:
+                items += response.value
+        return items
 
     async def get_member_groups(self, obj_id):
         request_body = GetMemberGroupsPostRequestBody(security_enabled_only=False)

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -59,6 +59,8 @@ options:
         description:
             - When true, I(group_members) contains transitive members (nested-group expansion).
             - When false, only direct members are returned.
+            - Note that the default membership view is direct members. In prior versions the
+              default view was transitive; set this option to C(true) to preserve that behavior.
         default: false
         type: bool
     all:

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -188,6 +188,7 @@ BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
 
 try:
     import asyncio
+    from kiota_abstractions.base_request_configuration import RequestConfiguration
     from msgraph.generated.groups.groups_request_builder import GroupsRequestBuilder
     from msgraph.generated.groups.item.get_member_groups.get_member_groups_post_request_body import \
         GetMemberGroupsPostRequestBody
@@ -374,13 +375,19 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         return await self.get_direct_group_members(group_id, filters)
 
     async def get_transitive_group_members(self, group_id, filters=None):
-        '''Query beta /groups/{id}/transitiveMembers; v1.0 omits servicePrincipal objects.'''
+        '''Query beta /groups/{id}/transitiveMembers; v1.0 omits servicePrincipal objects.
+
+        Graph classifies filtering on /transitiveMembers as an advanced query and
+        requires the ConsistencyLevel: eventual header; without it Graph returns 400.
+        '''
         url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
+        request_configuration = RequestConfiguration()
+        request_configuration.headers.try_add("ConsistencyLevel", "eventual")
         try:
             return await self._collect_paged_beta(
-                self._client.groups.by_group_id(group_id).transitive_members, url)
+                self._client.groups.by_group_id(group_id).transitive_members, url, request_configuration)
         except Exception:
             return
 
@@ -392,14 +399,17 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).members, url)
 
-    async def _collect_paged_beta(self, request_builder, initial_url):
+    async def _collect_paged_beta(self, request_builder, initial_url, request_configuration=None):
         '''Follow odata_next_link starting from a beta URL; SDK adapter/auth is preserved.'''
-        response = await request_builder.with_url(initial_url).get()
+        kwargs = {}
+        if request_configuration is not None:
+            kwargs["request_configuration"] = request_configuration
+        response = await request_builder.with_url(initial_url).get(**kwargs)
         items = []
         if response and response.value:
             items += response.value
         while response is not None and response.odata_next_link is not None:
-            response = await request_builder.with_url(response.odata_next_link).get()
+            response = await request_builder.with_url(response.odata_next_link).get(**kwargs)
             if response and response.value:
                 items += response.value
         return items

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -182,9 +182,7 @@ description:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
-from urllib.parse import quote
-
-BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
+from urllib.parse import quote, urlparse
 
 try:
     import asyncio
@@ -361,10 +359,19 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
 
         return groups
 
+    def _graph_base(self, version):
+        '''Return the Graph base URL for the tenant's cloud (e.g. https://graph.microsoft.us/beta).
+
+        Derived from the SDK request adapter so sovereign clouds (US Gov, China, Germany)
+        receive matching @odata.id and @odata.nextLink references.
+        '''
+        parsed = urlparse(self._client.request_adapter.base_url)
+        return "{0}://{1}/{2}".format(parsed.scheme, parsed.netloc, version)
+
     async def get_group_owners(self, group_id):
         '''Query beta /groups/{id}/owners; v1.0 omits servicePrincipal owners (documented).'''
         select = "id,displayName,userPrincipalName,mailNickname,mail,accountEnabled,userType,appId,appRoleAssignmentRequired"
-        url = "{0}/groups/{1}/owners?$select={2}".format(BETA_GRAPH_BASE_URL, group_id, select)
+        url = "{0}/groups/{1}/owners?$select={2}".format(self._graph_base("beta"), group_id, select)
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).owners, url)
 
@@ -380,7 +387,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         Graph classifies filtering on /transitiveMembers as an advanced query and
         requires the ConsistencyLevel: eventual header; without it Graph returns 400.
         '''
-        url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
+        url = "{0}/groups/{1}/transitiveMembers".format(self._graph_base("beta"), group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
         request_configuration = RequestConfiguration()
@@ -393,7 +400,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
 
     async def get_direct_group_members(self, group_id, filters=None):
         '''Query beta /groups/{id}/members; v1.0 omits servicePrincipal objects.'''
-        url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
+        url = "{0}/groups/{1}/members".format(self._graph_base("beta"), group_id)
         if filters:
             url += "?$filter={0}".format(quote(filters, safe=""))
         return await self._collect_paged_beta(

--- a/plugins/modules/azure_rm_adgroup_info.py
+++ b/plugins/modules/azure_rm_adgroup_info.py
@@ -182,6 +182,7 @@ description:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBase
+from urllib.parse import quote
 
 BETA_GRAPH_BASE_URL = "https://graph.microsoft.com/beta"
 
@@ -376,7 +377,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         '''Query beta /groups/{id}/transitiveMembers; v1.0 omits servicePrincipal objects.'''
         url = "{0}/groups/{1}/transitiveMembers".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            url += "?$filter={0}".format(filters)
+            url += "?$filter={0}".format(quote(filters, safe=""))
         try:
             return await self._collect_paged_beta(
                 self._client.groups.by_group_id(group_id).transitive_members, url)
@@ -387,7 +388,7 @@ class AzureRMADGroupInfo(AzureRMModuleBase):
         '''Query beta /groups/{id}/members; v1.0 omits servicePrincipal objects.'''
         url = "{0}/groups/{1}/members".format(BETA_GRAPH_BASE_URL, group_id)
         if filters:
-            url += "?$filter={0}".format(filters)
+            url += "?$filter={0}".format(quote(filters, safe=""))
         return await self._collect_paged_beta(
             self._client.groups.by_group_id(group_id).members, url)
 


### PR DESCRIPTION
##### SUMMARY
Fix #1931.
`azure_rm_adgroup` and `azure_rm_adgroup_info` now query the Microsoft Graph beta endpoint when listing group members and transitive members, which is Microsoft's documented workaround for a v1.0 API limitation that omits `servicePrincipal` objects (including Managed Identities) from the response. Because the previous v1.0-based read returned an incomplete list, the module recomputed the members-to-add set incorrectly and re-issued an add for principals that were already members, causing a `Request_BadRequest: "One or more added object references already exist"` failure on every re-run. The parameter `raw_membership` (which existed only to work around the same v1.0 behavior) is removed in this major-release change and replaced by `include_transitive_members`, which governs only the shape of the returned member list.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_adgroup.py
- plugins/modules/azure_rm_adgroup_info.py

##### ADDITIONAL INFORMATION
- List-members and list-transitive-members calls in both modules now target `https://graph.microsoft.com/beta/groups/{id}/members` and `.../transitiveMembers` via the SDK's `with_url()` mechanism; auth and pagination flow through the existing request adapter, no new SDK dependency is introduced.
- Add and remove operations remain on Graph v1.0 (they were never affected by the servicePrincipal-omission bug).
- `raw_membership` is removed from both modules' argument specs, examples, and returns. Playbooks that set `raw_membership: true` will need to remove the option or replace it with `include_transitive_members: true` when they want the transitive-members view in the return payload.
- `azure_rm_adgroup.exec_module` now surfaces exceptions to `self.fail(str(e))` instead of `self.fail(e)`, fixing the `TypeError: Value of unknown type: <class 'msgraph.generated.models.o_data_errors.o_data_error.ODataError'>` observed in the reporter's traceback whenever Graph raised any `ODataError`.
- `RETURN.group_members` documentation in both modules is updated to state that `servicePrincipal` objects (including Managed Identities) are included, and that direct membership is the default while transitive membership is opt-in via `include_transitive_members`.

##### REFERENCE
- https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
- https://learn.microsoft.com/en-us/graph/known-issues