### PR TITLE
CI Fix: Remove unused urlparse import from azure_rm_virtualmachine_info

### DIFF
--- a/plugins/modules/azure_rm_virtualmachine_info.py
+++ b/plugins/modules/azure_rm_virtualmachine_info.py
@@ -380,8 +380,6 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 
-from urllib.parse import urlparse
-
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 import re
 


### PR DESCRIPTION
##### SUMMARY
PR #2305 (six -> stdlib migration) replaced the `from ansible.module_utils.six.moves.urllib.parse import urlparse` shim with a stdlib `from urllib.parse import urlparse`, but `urlparse` has no callers in `azure_rm_virtualmachine_info.py`. The `pylint` sanity test now flags it as `unused-import: Unused urlparse imported from urllib.parse`, breaking sanity on every open PR against `dev`.

Fix: drop the import line. No behavior change.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_virtualmachine_info.py

##### ADDITIONAL INFORMATION
- Verified locally: `ansible-test sanity --test pep8 --test validate-modules --test pylint plugins/modules/azure_rm_virtualmachine_info.py --python 3.10` is clean after this change.
- `grep -n urlparse plugins/modules/azure_rm_virtualmachine_info.py` returns only the import line \u2014 no call sites.
- This unblocks sanity CI on all currently open PRs against `dev`, including #2339.

##### REFERENCE
- Introduced by: #2305 (Replace ansible.module_utils.six with Python stdlib equivalents)
- Blocking: #2339 (4.0.0 Removal: Delete retired MariaDB, MySQL Single, PostgreSQL Single Server modules)