### PR TITLE
azure_rm inventory - template cloud_environment option

### DIFF
--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -342,6 +342,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if self.templar.is_template(auth_options["subscription_id"]):
             auth_options["subscription_id"] = self.templar.template(variable=auth_options["subscription_id"], disable_lookups=False)
 
+        if self.templar.is_template(auth_options["cloud_environment"]):
+            auth_options["cloud_environment"] = self.templar.template(variable=auth_options["cloud_environment"], disable_lookups=False)
+
         self.azure_auth = AzureRMAuth(**auth_options)
 
         self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credential_track2, self.azure_auth.subscription_id,


### PR DESCRIPTION
##### SUMMARY

The azure_rm inventory plugin templates four of its auth options
(`tenant`, `client_id`, `secret`, `subscription_id`) in
`_credential_setup()`, but not `cloud_environment`. A Jinja expression
in that option is therefore passed through to `AzureRMAuth` verbatim
and rejected:

    Failed to parse <file>.azure_rm.yml with azure_rm plugin:
    cloud_environment must be an endpoint discovery URL or one of
    ['AzureChinaCloud', 'AzureGermanCloud', 'AzureCloud', 'AzureUSGovernment']

This makes it impossible to parameterise the cloud per environment in a
shared inventory file. `subscription_id` can be templated, so an
otherwise identical file can be reused across subscriptions — but the
moment those subscriptions live in different clouds, the value has to
be hardcoded and the file forked per environment.

The documented environment variable is not an alternative here. The
plugin only reads the environment explicitly for `auth_source`
(`environ.get('ANSIBLE_AZURE_AUTH_SOURCE', ...)`); there is no
equivalent for `cloud_environment`, and because the option carries a
default of `AzureCloud`, `get_option()` always returns a non-empty
value, so the credential env mapping in `azure_rm_common.py` never
applies. Omitting the option from the config file silently falls back
to the public cloud rather than honouring `AZURE_CLOUD_ENVIRONMENT`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/inventory/azure_rm.py

##### ADDITIONAL INFORMATION

The fix follows the existing pattern in the same function:

```python
if self.templar.is_template(auth_options["cloud_environment"]):
    auth_options["cloud_environment"] = self.templar.template(
        variable=auth_options["cloud_environment"], disable_lookups=False)
```

`is_template()` returns False for a plain string such as
`AzureUSGovernment`, so behaviour is unchanged for every existing
configuration. Only configs that currently fail begin to work.

Verified against a sovereign-cloud subscription using MSI auth:

```yaml
plugin: azure.azcollection.azure_rm
auth_source: msi
subscription_id: "{{ lookup('env', 'MY_SUBSCRIPTION_ID') }}"
cloud_environment: "{{ lookup('env', 'AZURE_CLOUD_ENVIRONMENT') }}"
```

Before the change: parse failure, zero hosts.
After: inventory populates normally.

Related: #893 reports a comparable problem with `cloud_environment`
not taking effect for MSI auth against a sovereign cloud.

Note that `profile`, `ad_user`, `password`, and `adfs_authority_url`
have the same omission. I've kept this PR minimal, but happy to extend
it — or to rework the block as a loop over the string auth options —
if maintainers prefer.