### PR TITLE
New Feature 1093: Add diff mode support to azure_rm_securitygroup

### DIFF
--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -742,6 +742,22 @@ rule_spec = dict(
     direction=dict(type='str', choices=['Inbound', 'Outbound'], default='Inbound')
 )
 
+# Denylist of Azure server-computed fields to strip from diff output.
+# Extend when future SDK versions leak new fields that produce diff churn.
+_DIFF_SCRUB_KEYS = frozenset((
+    'etag',
+    'provisioning_state',
+    'resource_guid',
+))
+
+
+def _scrub_diff(obj):
+    if isinstance(obj, dict):
+        return {k: _scrub_diff(v) for k, v in obj.items() if k not in _DIFF_SCRUB_KEYS}
+    if isinstance(obj, list):
+        return [_scrub_diff(item) for item in obj]
+    return obj
+
 
 class AzureRMSecurityGroup(AzureRMModuleBase):
 
@@ -903,8 +919,8 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
             if isinstance(after_state, dict) and after_state.get('status') == 'Deleted':
                 after_state = None
             self.results['diff'] = dict(
-                before=diff_before,
-                after=copy.deepcopy(after_state) if after_state else None,
+                before=_scrub_diff(diff_before) if diff_before else None,
+                after=_scrub_diff(after_state) if after_state else None,
             )
 
         return self.results

--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -530,6 +530,8 @@ state:
             sample: "Microsoft.Network/networkSecurityGroups"
 '''  # NOQA
 
+import copy
+
 try:
     from azure.core.exceptions import ResourceNotFoundError
     from azure.mgmt.core.tools import is_valid_resource_id
@@ -798,6 +800,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
 
         changed = False
         results = dict()
+        diff_before = None
 
         resource_group = self.get_resource_group(self.resource_group)
         if not self.location:
@@ -823,6 +826,8 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         try:
             nsg = self.network_client.network_security_groups.get(self.resource_group, self.name)
             results = create_network_security_group_dict(nsg)
+            if self.module._diff:
+                diff_before = copy.deepcopy(results)
             self.log("Found security group:")
             self.log(results, pretty_print=True)
             self.check_provisioning_state(nsg, self.state)
@@ -892,6 +897,15 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
                 # the delete does not actually return anything. if no exception, then we'll assume
                 # it worked.
                 self.results['state']['status'] = 'Deleted'
+
+        if self.module._diff:
+            after_state = self.results.get('state') or None
+            if isinstance(after_state, dict) and after_state.get('status') == 'Deleted':
+                after_state = None
+            self.results['diff'] = dict(
+                before=diff_before,
+                after=copy.deepcopy(after_state) if after_state else None,
+            )
 
         return self.results
 

--- a/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -132,6 +132,88 @@
       ansible.builtin.assert:
         that: output is not changed
 
+    - name: Add a rule with diff:true to exercise diff mode
+      azure.azcollection.azure_rm_securitygroup:
+        resource_group: "{{ resource_group }}-securitygroup01"
+        name: "{{ secgroupname }}"
+        rules:
+          - name: AllowSSH
+            protocol: Tcp
+            source_address_prefix: 174.108.158.0/24
+            destination_port_range: 22
+            access: Allow
+            priority: 101
+          - name: AllowSSHFromHome
+            protocol: Tcp
+            source_address_prefix: 174.109.158.0/24
+            destination_port_range: 22-23
+            priority: 102
+          - name: AllowHTTPandHTTPS
+            protocol: Tcp
+            source_address_prefix: 174.109.158.0/24
+            destination_port_range:
+              - 80
+              - 443
+            priority: 103
+          - name: DiffModeCanary
+            protocol: Tcp
+            source_address_prefix: 10.0.0.0/24
+            destination_port_range: 8080
+            access: Allow
+            priority: 200
+            direction: Inbound
+      diff: true
+      register: diff_output
+    - name: Assert diff mode reports before/after delta
+      ansible.builtin.assert:
+        that:
+          - diff_output is changed
+          - diff_output.diff is defined
+          - diff_output.diff.before is mapping
+          - diff_output.diff.after is mapping
+          - diff_output.diff.before.rules | length == 4
+          - diff_output.diff.after.rules | length == 5
+
+    - name: Re-run same rules with diff:true (idempotent)
+      azure.azcollection.azure_rm_securitygroup:
+        resource_group: "{{ resource_group }}-securitygroup01"
+        name: "{{ secgroupname }}"
+        rules:
+          - name: AllowSSH
+            protocol: Tcp
+            source_address_prefix: 174.108.158.0/24
+            destination_port_range: 22
+            access: Allow
+            priority: 101
+          - name: AllowSSHFromHome
+            protocol: Tcp
+            source_address_prefix: 174.109.158.0/24
+            destination_port_range: 22-23
+            priority: 102
+          - name: AllowHTTPandHTTPS
+            protocol: Tcp
+            source_address_prefix: 174.109.158.0/24
+            destination_port_range:
+              - 80
+              - 443
+            priority: 103
+          - name: DiffModeCanary
+            protocol: Tcp
+            source_address_prefix: 10.0.0.0/24
+            destination_port_range: 8080
+            access: Allow
+            priority: 200
+            direction: Inbound
+      diff: true
+      register: diff_idem_output
+    - name: Assert diff mode is idempotent
+      ansible.builtin.assert:
+        that:
+          - diff_idem_output is not changed
+          - diff_idem_output.diff is defined
+          - diff_idem_output.diff.before.rules | length == 5
+          - diff_idem_output.diff.after.rules | length == 5
+
     - name: Update tags
       azure.azcollection.azure_rm_securitygroup:
         resource_group: "{{ resource_group }}-securitygroup01"


### PR DESCRIPTION
##### SUMMARY
Fix #1093.
`azure_rm_securitygroup` now populates a `diff` key in its module return when the task is run with `diff: true`, so Ansible's `--diff` renderer shows the pre-update and post-update security-group state. Emission is gated on `self.module._diff`, so runs without diff mode are unchanged. Integration test coverage exercises both the changed-state and idempotent-state diff output.

##### ISSUE TYPE
- [x] New Feature Pull Request
- [ ] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_securitygroup.py
- tests/integration/targets/azure_rm_securitygroup/tasks/main.yml

##### ADDITIONAL INFORMATION
- Module snapshots the fetched NSG dict into `diff.before` (deep-copied) immediately after `create_network_security_group_dict(nsg)` and snapshots the post-update `self.results['state']` (or the check-mode intended state) into `diff.after` before returning.
- For the `absent`-then-deleted path, `diff.after` is normalized to `null` so the diff output reflects resource deletion cleanly.
- Diff emission is gated on `self.module._diff`; the module return payload is unchanged for tasks that do not request diff mode.
- Integration test adds two tasks: one applies a new rule with `diff: true` and asserts `diff.before.rules | length == 4` and `diff.after.rules | length == 5`; the second re-runs the same rules with `diff: true` and asserts idempotence with `before.rules | length == 5` and `after.rules | length == 5`.
- Follows the diff-mode pattern already used by `azure_rm_recoveryservicesvaultconfig` in this collection (see the collection-wide proposal in #1927).