### PR TITLE
New Module 1127: Add azure_rm_backupjob_info for querying backup job status

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -48,6 +48,7 @@ action_groups:
     - azure.azcollection.azure_rm_azurefirewall_info
     - azure.azcollection.azure_rm_backupazurevm
     - azure.azcollection.azure_rm_backupazurevm_info
+    - azure.azcollection.azure_rm_backupjob_info
     - azure.azcollection.azure_rm_backuppolicy
     - azure.azcollection.azure_rm_backuppolicy_info
     - azure.azcollection.azure_rm_bastionhost

--- a/plugins/modules/azure_rm_backupjob_info.py
+++ b/plugins/modules/azure_rm_backupjob_info.py
@@ -1,0 +1,176 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_backupjob_info
+version_added: '4.1.0'
+short_description: Get Azure Backup job status
+description:
+    - Query the status of a single Azure Recovery Services Backup job by name,
+      or list backup jobs on a Recovery Services vault.
+    - Wraps the SDK operations C(RecoveryServicesBackupClient.job_details.get) and
+      C(RecoveryServicesBackupClient.backup_jobs.list).
+options:
+    resource_group:
+        description:
+            - The name of the resource group containing the Recovery Services vault.
+        required: true
+        type: str
+    recovery_vault_name:
+        description:
+            - The name of the Azure Recovery Services vault.
+        required: true
+        type: str
+    name:
+        description:
+            - Job identifier (the job C(name) returned by the Azure Backup service).
+            - When set, only that job's details are returned.
+            - When not set, all backup jobs on the vault are listed.
+        type: str
+    filter:
+        description:
+            - OData filter applied when listing jobs. Ignored when I(name) is set.
+            - "Example: C(status eq 'InProgress' and backupManagementType eq 'AzureIaasVM')."
+        type: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Get status of a specific backup job
+  azure_rm_backupjob_info:
+    resource_group: my-rg
+    recovery_vault_name: testVault
+    name: 6c33c123-abcd-4567-89ef-000000000000
+
+- name: List in-progress backup jobs on the vault
+  azure_rm_backupjob_info:
+    resource_group: my-rg
+    recovery_vault_name: testVault
+    filter: "status eq 'InProgress'"
+'''
+
+RETURN = '''
+jobs:
+    description:
+        - List of backup job objects.
+        - Contains a single element when I(name) is provided.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        id:
+            description: Fully qualified resource ID of the backup job.
+            returned: always
+            type: str
+        name:
+            description: Job identifier.
+            returned: always
+            type: str
+        type:
+            description: Resource type (C(Microsoft.RecoveryServices/vaults/backupJobs)).
+            returned: always
+            type: str
+        properties:
+            description: Job properties including operation, status, start/end time, and source entity.
+            returned: always
+            type: dict
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    # handled in azure_rm_common
+    pass
+
+
+class AzureRMBackupJobInfo(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(
+                type='str',
+                required=True
+            ),
+            recovery_vault_name=dict(
+                type='str',
+                required=True
+            ),
+            name=dict(
+                type='str'
+            ),
+            filter=dict(
+                type='str'
+            ),
+        )
+
+        self.resource_group = None
+        self.recovery_vault_name = None
+        self.name = None
+        self.filter = None
+
+        self.results = dict(changed=False, jobs=[])
+
+        super(AzureRMBackupJobInfo, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.name:
+            job = self.get_job()
+            self.results['jobs'] = [job.as_dict()] if job is not None else []
+        else:
+            self.results['jobs'] = [j.as_dict() for j in self.list_jobs()]
+
+        return self.results
+
+    def get_job(self):
+        try:
+            return self.recovery_services_backup_client.job_details.get(
+                vault_name=self.recovery_vault_name,
+                resource_group_name=self.resource_group,
+                job_name=self.name,
+            )
+        except ResourceNotFoundError:
+            self.log("Backup job {0} not found on vault {1}".format(self.name, self.recovery_vault_name))
+            return None
+        except Exception as exc:
+            self.fail("Error fetching backup job {0}: {1}".format(self.name, str(exc)))
+
+    def list_jobs(self):
+        try:
+            pager = self.recovery_services_backup_client.backup_jobs.list(
+                vault_name=self.recovery_vault_name,
+                resource_group_name=self.resource_group,
+                filter=self.filter,
+            )
+            return list(pager)
+        except Exception as exc:
+            self.fail("Error listing backup jobs on vault {0}: {1}".format(self.recovery_vault_name, str(exc)))
+
+
+def main():
+    AzureRMBackupJobInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -297,6 +297,8 @@ jobs:
           test.key: '18'
         "Python${{ parameters.PYTHON_VER }}_19":
           test.key: '19'
+        "Python${{ parameters.PYTHON_VER }}_20":
+          test.key: '20'
 
     steps:
       - task: UsePythonVersion@0

--- a/tests/integration/targets/azure_rm_backupazurevm/aliases
+++ b/tests/integration/targets/azure_rm_backupazurevm/aliases
@@ -1,4 +1,3 @@
 cloud/azure
-shippable/azure/group12
+shippable/azure/group20
 destructive
-disabled

--- a/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
@@ -1,86 +1,217 @@
 - name: Create a new resource group for backup azure VM test
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-backupazurevm"
-    location: eastus
+    location: eastus2
 
 - name: For backup azure VM test
   block:
-    - name: Fix resource prefix
+    - name: Set facts
       ansible.builtin.set_fact:
-        resource_group: 'MyResourceGroup'
-        recovery_vault_name: 'MyRecoveryVault'
-        resource_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/MyVM"
-        backup_policy_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/microsoft.recoveryservices/vaults/testVault/backupPolicies/DefaultPolicy"
+        rpfx: "{{ resource_group | hash('md5') | truncate(10, True, '') }}"
+        location: "eastus2"
+        recovery_vault_name: "rsv{{ resource_group | hash('md5') | truncate(22, True, '') }}"
+        policy_name: "bp-daily-{{ resource_group | hash('md5') | truncate(16, True, '') }}"
+        vm_name: "bkvm{{ resource_group | hash('md5') | truncate(10, True, '') }}"
 
-    - name: Enabling/Updating protection for the Azure VM
+    - name: Create virtual network
+      azure.azcollection.azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        name: "vnet-{{ rpfx }}"
+        address_prefixes: "10.0.0.0/16"
+
+    - name: Add subnet
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        name: "subnet-{{ rpfx }}"
+        address_prefix: "10.0.1.0/24"
+        virtual_network: "vnet-{{ rpfx }}"
+
+    - name: Create network interface
+      azure.azcollection.azure_rm_networkinterface:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        name: "nic-{{ rpfx }}"
+        virtual_network: "vnet-{{ rpfx }}"
+        subnet: "subnet-{{ rpfx }}"
+        create_with_security_group: false
+        ip_configurations:
+          - name: default
+            primary: true
+
+    - name: Create the VM to be protected
+      azure.azcollection.azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        name: "{{ vm_name }}"
+        vm_size: Standard_D2s_v3
+        admin_username: azureuser
+        ssh_password_enabled: false
+        ssh_public_keys:
+          - path: /home/azureuser/.ssh/authorized_keys
+            key_data: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfoYlIV4lTPZTv7hXaVwQQuqBgGs4yeNRX0SPo2+HQt9u4X7IGwrtXc0nEUm6LfaCikMH58bOL8f20NTGz285kxdFHZRcBXtqmnMz2rXwhK9gwq5h1khc+GzHtdcJXsGA4y0xuaNcidcg04jxAlN/06fwb/VYwwWTVbypNC0gpGEpWckCNm8vlDlA55sU5et0SZ+J0RKVvEaweUOeNbFZqckGPA384imfeYlADppK/7eAxqfBVadVvZG8IJk4yvATgaIENIFj2cXxqu2mQ/Bp5Wr45uApvJsFXmi+v/nkiOEV1QpLOnEwAZo6EfFS4CCQtsymxJCl1PxdJ5LD4ZOtP xiuxi.sun@qq.com"
+        network_interfaces: "nic-{{ rpfx }}"
+        managed_disk_type: StandardSSD_LRS
+        os_disk_caching: ReadWrite
+        image:
+          offer: 0001-com-ubuntu-server-focal
+          publisher: canonical
+          sku: 20_04-lts-gen2
+          version: latest
+      register: vm_out
+
+    - name: Create Recovery Services vault
+      azure.azcollection.azure_rm_recoveryservicesvault:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        name: "{{ recovery_vault_name }}"
+        location: "{{ location }}"
+        state: present
+
+    - name: Create daily VM backup policy
+      azure.azcollection.azure_rm_backuppolicy:
+        vault_name: "{{ recovery_vault_name }}"
+        name: "{{ policy_name }}"
+        resource_group: "{{ resource_group }}-backupazurevm"
+        state: present
+        backup_management_type: "AzureIaasVM"
+        schedule_run_frequency: "Daily"
+        instant_recovery_snapshot_retention: 2
+        daily_retention_count: 7
+        time_zone: "UTC"
+        schedule_run_time: 14
+      register: policy_out
+
+    - name: Enable protection for the Azure VM
       azure.azcollection.azure_rm_backupazurevm:
         resource_group: "{{ resource_group }}-backupazurevm"
         recovery_vault_name: "{{ recovery_vault_name }}"
-        resource_id: "{{ resource_id }}"
-        backup_policy_id: "{{ backup_policy_id }}"
-        state: "create"
-      register: output
+        resource_id: "{{ vm_out.ansible_facts.azure_vm.id }}"
+        backup_policy_id: "{{ policy_out.id }}"
+        state: create
+      register: enable_out
 
-    - name: Assert that output has changed
+    - name: Assert protection enable succeeded
       ansible.builtin.assert:
         that:
-          - output is changed
+          - enable_out is changed
+          - enable_out.response.id is defined
 
-    - name: Trigger an on-demand backup for a protected Azure VM
-      azure.azcollection.azure_rm_backupazurevm:
+    - name: Get protected item info
+      azure.azcollection.azure_rm_backupazurevm_info:
         resource_group: "{{ resource_group }}-backupazurevm"
         recovery_vault_name: "{{ recovery_vault_name }}"
-        resource_id: "{{ resource_id }}"
-        backup_policy_id: "{{ backup_policy_id }}"
-        recovery_point_expiry_time: "2025-02-03T05:00:00Z"
-        state: "backup"
-      register: output
+        resource_id: "{{ vm_out.ansible_facts.azure_vm.id }}"
+      register: protected_info
 
-    - name: Assert that output has changed
+    - name: Assert protected item is returned
       ansible.builtin.assert:
         that:
-          - output is changed
+          - protected_info.response.id is defined
+          - protected_info.response.name is defined
+
+    # Skipped on purpose: triggering an on-demand backup creates a recovery
+    # point that Azure's secure-by-default policy retains under 14-day soft
+    # delete (BMSUserErrorDisablingSoftDeleteStateNotAllowed prevents
+    # opt-out), which blocks vault + RG teardown and leaves the RG billable
+    # for 14 days per run. The ConfigureBackup job emitted by `state: create`
+    # above is sufficient to exercise azure_rm_backupjob_info.
+    # - name: Trigger on-demand backup
+    #   azure.azcollection.azure_rm_backupazurevm:
+    #     resource_group: "{{ resource_group }}-backupazurevm"
+    #     recovery_vault_name: "{{ recovery_vault_name }}"
+    #     resource_id: "{{ vm_out.ansible_facts.azure_vm.id }}"
+    #     backup_policy_id: "{{ policy_out.id }}"
+    #     recovery_point_expiry_time: "2026-12-31T00:00:00Z"
+    #     state: backup
+    #   register: backup_trigger
+    #
+    # - name: Assert backup was triggered
+    #   ansible.builtin.assert:
+    #     that:
+    #       - backup_trigger is changed
+
+    - name: List backup jobs on the vault until a ConfigureBackup job appears
+      azure.azcollection.azure_rm_backupjob_info:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        recovery_vault_name: "{{ recovery_vault_name }}"
+      register: all_jobs
+      until: all_jobs.jobs | selectattr('properties.operation', 'equalto', 'ConfigureBackup') | list | length > 0
+      retries: 60
+      delay: 20
+
+    - name: Assert list returned at least one job
+      ansible.builtin.assert:
+        that:
+          - all_jobs.jobs | length > 0
+
+    - name: List only in-progress jobs (filter smoke test)
+      azure.azcollection.azure_rm_backupjob_info:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        recovery_vault_name: "{{ recovery_vault_name }}"
+        filter: "status eq 'InProgress'"
+      register: filtered_jobs
+
+    - name: Assert filter did not error and returned a list
+      ansible.builtin.assert:
+        that:
+          - filtered_jobs.jobs is iterable
+
+    - name: Pick the ConfigureBackup job from the enrollment above
+      ansible.builtin.set_fact:
+        target_job: "{{ all_jobs.jobs | selectattr('properties.operation', 'equalto', 'ConfigureBackup') | list | first }}"
+
+    - name: Get details for a specific job by name
+      azure.azcollection.azure_rm_backupjob_info:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        recovery_vault_name: "{{ recovery_vault_name }}"
+        name: "{{ target_job.name }}"
+      register: job_detail
+
+    - name: Assert single-element job detail and known status
+      ansible.builtin.assert:
+        that:
+          - job_detail.jobs | length == 1
+          - job_detail.jobs[0].name == target_job.name
+          - job_detail.jobs[0].properties.operation == 'ConfigureBackup'
+          - job_detail.jobs[0].properties.status in ['InProgress', 'Completed', 'CompletedWithWarnings', 'Failed', 'Cancelling', 'Cancelled']
+
+    - name: Get details for a non-existent job (typed 404 handling)
+      azure.azcollection.azure_rm_backupjob_info:
+        resource_group: "{{ resource_group }}-backupazurevm"
+        recovery_vault_name: "{{ recovery_vault_name }}"
+        name: "00000000-0000-0000-0000-000000000000"
+      register: missing_job
+
+    - name: Assert missing job returns empty list
+      ansible.builtin.assert:
+        that:
+          - missing_job.jobs == []
 
     - name: Stop protection but retain existing data
       azure.azcollection.azure_rm_backupazurevm:
         resource_group: "{{ resource_group }}-backupazurevm"
         recovery_vault_name: "{{ recovery_vault_name }}"
-        resource_id: "{{ resource_id }}"
-        backup_policy_id: "{{ backup_policy_id }}"
-        state: "stop"
-      register: output
+        resource_id: "{{ vm_out.ansible_facts.azure_vm.id }}"
+        backup_policy_id: "{{ policy_out.id }}"
+        state: stop
+      register: stop_out
 
-    - name: Assert that output has changed
+    - name: Assert stop succeeded
       ansible.builtin.assert:
         that:
-          - output is changed
+          - stop_out is changed
 
-    - name: Get backup azure vm info
-      azure.azcollection.azure_rm_backupazurevm_info:
-        resource_group: "{{ resource_group }}-backupazurevm"
-        recovery_vault_name: "{{ recovery_vault_name }}"
-        resource_id: "{{ resource_id }}"
-      register: output
-
-    - name: Assert that output has changed
-      ansible.builtin.assert:
-        that:
-          - output.response.id != None
-          - output.response.name != None
-
-    - name: Stop protection and delete data
+    - name: Stop protection and delete backup data
       azure.azcollection.azure_rm_backupazurevm:
         resource_group: "{{ resource_group }}-backupazurevm"
         recovery_vault_name: "{{ recovery_vault_name }}"
-        resource_id: "{{ resource_id }}"
-        backup_policy_id: "{{ backup_policy_id }}"
-        state: "delete"
-      register: output
+        resource_id: "{{ vm_out.ansible_facts.azure_vm.id }}"
+        backup_policy_id: "{{ policy_out.id }}"
+        state: delete
+      register: delete_out
 
-    - name: Assert that output has changed
+    - name: Assert delete succeeded
       ansible.builtin.assert:
         that:
-          - output is changed
+          - delete_out is changed
+
   always:
     - name: Force delete the resource group
       azure.azcollection.azure_rm_resourcegroup:


### PR DESCRIPTION
##### SUMMARY
Fix #1127.
Adds a new info module `azure_rm_backupjob_info` that wraps the Azure Recovery Services Backup `JobDetails.Get` and `BackupJobs.List` operations, so playbooks can query the status of a specific backup job by name or list jobs on a vault with an OData filter. Enables the `until:` / `retries:` polling pattern the reporter needed to wait for backup completion. The previously-disabled `azure_rm_backupazurevm` integration target is converted into a real vault + policy + VM lifecycle test that also exercises the new module in its own ADO group.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [x] New Module Pull Request
- [ ] Bug Fix Pull Request
- [x] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_backupjob_info.py
- meta/runtime.yml
- tests/integration/targets/azure_rm_backupazurevm/aliases
- tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml
- pr-pipelines.yml

##### ADDITIONAL INFORMATION
- New `azure_rm_backupjob_info` module: `name:` calls `RecoveryServicesBackupClient.job_details.get(vault_name, resource_group_name, job_name)`; omitting `name:` calls `backup_jobs.list(...)` and consumes the SDK's `ItemPaged` iterator so pagination is transparent. `filter:` maps to the OData `$filter` query parameter (T1: `azure-sdk-for-python/sdk/recoveryservices/azure-mgmt-recoveryservicesbackup/.../_client.py` — `:ivar job_details: JobDetailsOperations`, `:ivar backup_jobs: BackupJobsOperations`).
- Typed 404 handling: catches `azure.core.exceptions.ResourceNotFoundError` and returns an empty `jobs` list instead of raising, so idempotent polling loops don't fail when a job id is missing (T1: `azure-sdk-for-python/sdk/core/azure-core/azure/core/exceptions.py`).
- Module inherits from `AzureRMModuleBase` with `facts_module=True`, matching the SDK-backed sibling `azure_rm_recoveryservicesvaultconfig_info`. API version is inherited from `azure-mgmt-recoveryservicesbackup==9.1.0` already pinned in `requirements.txt`; no hardcoded api-version string.
- `meta/runtime.yml`: registers `azure.azcollection.azure_rm_backupjob_info` in `action_groups.all` between `azure_rm_backupazurevm_info` and `azure_rm_backuppolicy` to preserve alphabetical ordering.
- `tests/integration/targets/azure_rm_backupazurevm/tasks/main.yml`: replaces the previously-disabled all-zero placeholder scaffold with a real end-to-end run — provisions vnet + subnet + nic + Ubuntu VM + Recovery Services vault + daily VM backup policy, then exercises `azure_rm_backupazurevm` `state: create` / `state: stop` / `state: delete` and the new `azure_rm_backupjob_info` module (list, `filter: "status eq 'InProgress'"` smoke, `name:` single lookup, synthetic all-zero name to hit the 404 path). The on-demand `state: backup` step is intentionally commented out — Azure's secure-by-default 14-day soft delete for recovery points blocks vault/RG teardown (`BMSUserErrorDisablingSoftDeleteStateNotAllowed` prevents opting out), so the enrollment-emitted `ConfigureBackup` job is polled instead.
- `tests/integration/targets/azure_rm_backupazurevm/aliases`: removes `disabled` and moves the target from `shippable/azure/group12` to a dedicated `shippable/azure/group20` so the ~5–10 min backup lifecycle does not extend group12's runtime.
- `pr-pipelines.yml`: adds the matrix entry `"Python${{ parameters.PYTHON_VER }}_20": test.key: '20'` so the ADO pipeline dispatches the new group.

##### REFERENCE
- https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/recoveryservices/azure-mgmt-recoveryservicesbackup
- https://learn.microsoft.com/en-us/rest/api/backup/job-details/get?tabs=HTTP
- https://learn.microsoft.com/en-us/rest/api/backup/backup-jobs/list?tabs=HTTP