### PR TITLE
Fix 2253: Surface x-ms-* headers and ODataV4 errors on Azure failures

### DIFF
--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -130,7 +130,8 @@ options:
             - Path to a per-invocation debug log file written by this module when I(log_mode=file).
             - The file is created with mode 0o600 (owner read/write only) and rotated at 10 MB (up to 5 backups).
             - Distinct from and complementary to Ansible-core's C(ANSIBLE_LOG_PATH) which captures playbook-level output on the controller.
-            - Records SDK diagnostics under the C(azure.azcollection) logger including the module invocation correlation_id and, on failure, the ODataV4 error body plus C(x-ms-request-id) / C(x-ms-correlation-request-id) headers.
+            - Records SDK diagnostics under the C(azure.azcollection) logger, including the module invocation correlation_id.
+            - On failure, the log also captures the ODataV4 error body plus C(x-ms-request-id) and C(x-ms-correlation-request-id) headers.
         type: str
     log_mode:
         description:
@@ -138,7 +139,8 @@ options:
             - C(normal) (default) emits only WARNING-level records and matches historical behavior.
             - C(file) requires I(log_path) and writes DEBUG-level SDK diagnostics to that rotating file.
             - C(debug) elevates the effective log level to DEBUG regardless of Ansible verbosity.
-            - Automatically elevated to DEBUG when Ansible is invoked with C(-vvv) (or higher) or when the C(AZURE_LOG_LEVEL) environment variable is set to C(DEBUG), C(INFO), C(WARNING), C(ERROR), or C(CRITICAL).
+            - Automatically elevated to DEBUG when Ansible is invoked with C(-vvv) (or higher).
+            - Also elevated when C(AZURE_LOG_LEVEL) is set to C(DEBUG), C(INFO), C(WARNING), C(ERROR), or C(CRITICAL).
         type: str
         choices: [normal, file, debug]
         default: normal

--- a/plugins/doc_fragments/azure.py
+++ b/plugins/doc_fragments/azure.py
@@ -127,12 +127,21 @@ options:
         version_added: '0.0.1'
     log_path:
         description:
-            - Parent argument.
+            - Path to a per-invocation debug log file written by this module when I(log_mode=file).
+            - The file is created with mode 0o600 (owner read/write only) and rotated at 10 MB (up to 5 backups).
+            - Distinct from and complementary to Ansible-core's C(ANSIBLE_LOG_PATH) which captures playbook-level output on the controller.
+            - Records SDK diagnostics under the C(azure.azcollection) logger including the module invocation correlation_id and, on failure, the ODataV4 error body plus C(x-ms-request-id) / C(x-ms-correlation-request-id) headers.
         type: str
     log_mode:
         description:
-            - Parent argument.
+            - Verbosity mode for the collection's stdlib logger (C(azure.azcollection)).
+            - C(normal) (default) emits only WARNING-level records and matches historical behavior.
+            - C(file) requires I(log_path) and writes DEBUG-level SDK diagnostics to that rotating file.
+            - C(debug) elevates the effective log level to DEBUG regardless of Ansible verbosity.
+            - Automatically elevated to DEBUG when Ansible is invoked with C(-vvv) (or higher) or when the C(AZURE_LOG_LEVEL) environment variable is set to C(DEBUG), C(INFO), C(WARNING), C(ERROR), or C(CRITICAL).
         type: str
+        choices: [normal, file, debug]
+        default: normal
     x509_certificate_path:
         description:
             - Path to the X509 certificate used to create the service principal in PEM format.

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -14,6 +14,9 @@ import copy
 import inspect
 import traceback
 import json
+import logging
+import logging.handlers
+import uuid
 
 from os.path import expanduser
 import configparser
@@ -45,7 +48,7 @@ AZURE_COMMON_ARGS = dict(
     cert_validation_mode=dict(type='str', choices=['validate', 'ignore']),
     api_profile=dict(type='str', default='latest'),
     adfs_authority_url=dict(type='str', default=None),
-    log_mode=dict(type='str', no_log=True),
+    log_mode=dict(type='str', choices=['normal', 'file', 'debug'], default='normal', no_log=True),
     log_path=dict(type='str', no_log=True),
     x509_certificate_path=dict(type='path', no_log=True),
     thumbprint=dict(type='str', no_log=True),
@@ -76,6 +79,34 @@ AZURE_CREDENTIAL_ENV_MAPPING = dict(
 AZURE_CREDENTIAL_ENV_MAPPING_FALLBACK = dict(
     tenant='AZURE_TENANT_ID',
 )
+
+# Named logger per azure-sdk-for-python design guidelines.
+AZCOLLECTION_LOGGER_NAME = 'azure.azcollection'
+
+# Response headers redacted from fail_azure payloads and pipeline traces.
+SENSITIVE_RESPONSE_HEADERS = frozenset({
+    'authorization', 'cookie', 'set-cookie',
+    'x-ms-encryption-key', 'x-ms-encryption-key-sha256',
+    'x-ms-copy-source-authorization',
+    'x-ms-authorization-auxiliary',
+})
+
+
+class _AzcollectionCorrelationFilter(logging.Filter):
+    def __init__(self, correlation_id):
+        super().__init__()
+        self.correlation_id = correlation_id
+
+    def filter(self, record):
+        record.correlation_id = self.correlation_id
+        return True
+
+
+class SecureRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    # Creates the log file with 0o600 permissions (owner read/write only).
+    def _open(self):
+        fd = os.open(self.baseFilename, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        return os.fdopen(fd, self.mode, encoding=self.encoding)
 
 
 class SDKProfile(object):  # pylint: disable=too-few-public-methods
@@ -384,6 +415,9 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if,
                                     required_by=required_by)
 
+        self.correlation_id = str(uuid.uuid4())
+        self._configure_azure_logging()
+
         if AZURE_IMPORT_ERROR:
             missing_mod = _extract_missing_module(AZURE_IMPORT_ERROR)
 
@@ -482,14 +516,132 @@ class AzureRMModuleBase(object):
         '''
         self.module.fail_json(msg=msg, **kwargs)
 
+    def fail_azure(self, exception, msg=None, **kwargs):
+        '''
+        Fail with structured azure-core exception detail.
+
+        Surfaces status_code, x-ms-request-id, x-ms-correlation-request-id,
+        redacted response headers, and ODataV4 error fields (code, message,
+        target, details, innererror).
+        Binds to azure.core.exceptions.HttpResponseError public shape.
+        '''
+        try:
+            from azure.core.exceptions import HttpResponseError, AzureError
+        except ImportError:
+            self.module.fail_json(msg=str(msg or exception), exception=traceback.format_exc())
+            return
+
+        last_traceback = traceback.format_exc()
+        except_msg = str(getattr(exception, 'message', None) or exception)
+        message = "{0}: {1}".format(msg, except_msg) if msg else except_msg
+
+        failure = dict(msg=message, exception=last_traceback,
+                       correlation_id=getattr(self, 'correlation_id', None))
+        failure.update(kwargs)
+
+        if isinstance(exception, HttpResponseError):
+            response = getattr(exception, 'response', None)
+            headers = dict(getattr(response, 'headers', {}) or {}) if response else {}
+            failure['response_metadata'] = {
+                'status_code': getattr(exception, 'status_code', None),
+                'reason': getattr(exception, 'reason', None),
+                'request_id': headers.get('x-ms-request-id'),
+                'correlation_request_id': headers.get('x-ms-correlation-request-id'),
+                'http_headers': {k: ('[REDACTED]' if k.lower() in SENSITIVE_RESPONSE_HEADERS else v)
+                                 for k, v in headers.items()},
+            }
+            odata = getattr(exception, 'error', None)
+            if odata is not None:
+                failure['error'] = {
+                    'code': getattr(odata, 'code', None),
+                    'message': getattr(odata, 'message', None),
+                    'target': getattr(odata, 'target', None),
+                    'details': [
+                        {'code': d.code, 'message': d.message, 'target': d.target}
+                        for d in (getattr(odata, 'details', None) or [])
+                    ],
+                    'innererror': getattr(odata, 'innererror', None) or {},
+                }
+            ct = getattr(exception, 'continuation_token', None)
+            if ct:
+                failure['continuation_token'] = ct
+        elif isinstance(exception, AzureError):
+            failure['transport_error'] = True
+
+        logging.getLogger(AZCOLLECTION_LOGGER_NAME).warning('azcollection failure: %s', message)
+        self.module.fail_json(**failure)
+
+    def _configure_azure_logging(self):
+        '''
+        Configure the ``azure.azcollection`` named logger for this module invocation.
+
+        Effective level derives from (highest priority first):
+          1. ``AZURE_LOG_LEVEL`` env var
+          2. ``log_mode: debug`` module argument
+          3. Ansible verbosity (-vvv+ -> DEBUG, -v/-vv -> INFO, else WARNING)
+        When ``log_mode: file`` is set with ``log_path``, an additional rotating
+        DEBUG-level file handler (mode 0o600, 10 MB x 5 backups) is attached.
+        '''
+        logger = logging.getLogger(AZCOLLECTION_LOGGER_NAME)
+        for h in list(logger.handlers):
+            if getattr(h, '_azcollection_managed', False):
+                logger.removeHandler(h)
+                try:
+                    h.close()
+                except Exception:
+                    pass
+
+        log_mode = self.module.params.get('log_mode') or 'normal'
+        log_path = self.module.params.get('log_path')
+        verbosity = getattr(self.module, '_verbosity', 0) or 0
+        env_level = (os.environ.get('AZURE_LOG_LEVEL') or '').upper()
+
+        if env_level in ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'):
+            level = getattr(logging, env_level)
+        elif log_mode == 'debug' or verbosity >= 3:
+            level = logging.DEBUG
+        elif verbosity >= 1:
+            level = logging.INFO
+        else:
+            level = logging.WARNING
+
+        # File logging always wants DEBUG regardless of console verbosity; the
+        # logger's own gate would otherwise drop records before the file handler.
+        if log_mode == 'file' and log_path:
+            logger.setLevel(logging.DEBUG)
+        else:
+            logger.setLevel(level)
+        logger.propagate = False
+
+        formatter = logging.Formatter(
+            '%(asctime)s %(levelname)s %(name)s [correlation_id=%(correlation_id)s]: %(message)s',
+            datefmt='%Y-%m-%dT%H:%M:%S',
+        )
+        correlation_filter = _AzcollectionCorrelationFilter(self.correlation_id)
+
+        if log_mode == 'file' and log_path:
+            try:
+                file_handler = SecureRotatingFileHandler(
+                    expanduser(log_path), maxBytes=10 * 1024 * 1024, backupCount=5,
+                )
+                file_handler.setLevel(logging.DEBUG)
+                file_handler.setFormatter(formatter)
+                file_handler.addFilter(correlation_filter)
+                file_handler._azcollection_managed = True
+                logger.addHandler(file_handler)
+            except (OSError, PermissionError) as exc:
+                self.module.warn("Unable to open azcollection log file '{0}': {1}".format(log_path, str(exc)))
+
+        logger.info('module invocation correlation_id=%s', self.correlation_id)
+
     def deprecate(self, msg, version=None, collection_name='azure.azcollection'):
         self.module.deprecate(msg, version, collection_name=collection_name)
 
     def log(self, msg, pretty_print=False):
         if pretty_print:
-            self.module.debug(json.dumps(msg, indent=4, sort_keys=True))
-        else:
-            self.module.debug(msg)
+            msg = json.dumps(msg, indent=4, sort_keys=True)
+        self.module.debug(msg)
+        logging.getLogger(AZCOLLECTION_LOGGER_NAME).debug(msg)
 
     def validate_tags(self, tags):
         '''
@@ -1987,11 +2139,6 @@ class AzureRMAuth(object):
         return next(cloud for cloud in _knownClouds if cloud.endpoints.resource_manager.lower().rstrip('/') == metadata_endpoint.lower().rstrip('/'))
 
     def log(self, msg, pretty_print=False):
-        pass
-        # Use only during module development
-        # if self.debug:
-        #     log_file = open('azure_rm.log', 'a')
-        #     if pretty_print:
-        #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
-        #     else:
-        #         log_file.write(msg + u'\n')
+        if pretty_print:
+            msg = json.dumps(msg, indent=4, sort_keys=True)
+        logging.getLogger(AZCOLLECTION_LOGGER_NAME + '.auth').debug(msg)

--- a/plugins/module_utils/azure_rm_common_rest.py
+++ b/plugins/module_utils/azure_rm_common_rest.py
@@ -14,6 +14,7 @@ except Exception:
 try:
     from azure.core._pipeline_client import PipelineClient
     from azure.core.polling import LROPoller
+    from azure.core.exceptions import HttpResponseError
     from azure.core.pipeline import PipelineResponse
     from azure.core.pipeline.policies import BearerTokenCredentialPolicy, UserAgentPolicy
     from azure.mgmt.core.polling.arm_polling import ARMPolling
@@ -113,10 +114,4 @@ class GenericRestClient(object):
         error_type = self.error_map.get(response.status_code)
         if error_type:
             raise error_type(response=response)
-        raise SendRequestException(response.text(), response.status_code)
-
-
-class SendRequestException(Exception):
-    def __init__(self, response, status_code):
-        self.response = response
-        self.status_code = status_code
+        raise HttpResponseError(response=response)

--- a/plugins/modules/azure_rm_resource_info.py
+++ b/plugins/modules/azure_rm_resource_info.py
@@ -318,6 +318,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
 
 try:
     from azure.mgmt.core.tools import resource_id
+    from azure.core.exceptions import HttpResponseError
     import json
 
 except ImportError:
@@ -449,7 +450,11 @@ class AzureRMResourceInfo(AzureRMModuleBase):
         while True:
             if skiptoken:
                 query_parameters['skiptoken'] = skiptoken
-            response = self.mgmt_client.query(self.url, self.method, query_parameters, header_parameters, None, [200, 404], 0, 0)
+            try:
+                response = self.mgmt_client.query(self.url, self.method, query_parameters, header_parameters, None, [200, 404], 0, 0)
+            except HttpResponseError as e:
+                self.fail_azure(e, msg='Azure REST query failed')
+                return
             try:
                 if isinstance(response.body(), bytes) and bool(response.body().decode()) is False:
                     self.results['status_code'] = response.status_code


### PR DESCRIPTION
##### SUMMARY
Fix #2253.
`azure_rm_resource_info` now surfaces Azure's `x-ms-request-id`, `x-ms-correlation-request-id`, the full response-header dict, and the ODataV4 error body (`code`, `message`, `target`, `details`, `innererror`) on failure. A new `fail_azure` helper on `AzureRMModuleBase` provides the same structured failure payload for every module, and the previously-nonfunctional `log_mode` and `log_path` module arguments now attach a rotating, mode-0o600 debug log at `log_path` with a per-invocation `correlation_id`.

##### ISSUE TYPE
- [x] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [x] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_resource_info.py
- plugins/module_utils/azure_rm_common.py
- plugins/module_utils/azure_rm_common_rest.py
- plugins/doc_fragments/azure.py

##### ADDITIONAL INFORMATION
- `azure_rm_resource_info` failures now include `correlation_id`, `response_metadata.{status_code,reason,request_id,correlation_request_id,http_headers}`, and `error.{code,message,target,details,innererror}` (cited: `azure.core.exceptions.HttpResponseError` and `ODataV4Format` public shape in `Azure/azure-sdk-for-python`).
- `AzureRMModuleBase.fail_azure(exception, msg=None, **kwargs)` is available for every module to route `azure.core.exceptions.HttpResponseError` (and `AzureError`) into a structured failure payload with redacted sensitive headers.
- `GenericRestClient.on_error` fallback now raises `azure.core.exceptions.HttpResponseError(response=response)` instead of `SendRequestException`, preserving the `HttpResponse` object so headers survive to the caller; the unreferenced `SendRequestException` class is removed.
- `log_mode` gains real semantics: `normal` (default, unchanged behavior), `file` (attaches a `SecureRotatingFileHandler` at `log_path` — mode 0o600, 10 MB × 5 backups), and `debug` (raises the `azure.azcollection` logger level to DEBUG). Auto-elevates to DEBUG when Ansible is invoked with `-vvv` or when `AZURE_LOG_LEVEL` is set to a standard level.
- Every module invocation now generates a UUID4 `correlation_id` that appears in the log file and in `fail_azure` failure payloads for cross-record traceability.
- `AzureRMModuleBase.log()` and `AzureRMAuth.log()` now emit through the `azure.azcollection` named logger in addition to Ansible's debug channel, so existing `self.log(...)` sites automatically populate the new log file when `log_mode: file` is set.
- `plugins/doc_fragments/azure.py` replaces the stale `"Parent argument."` descriptions for `log_mode` and `log_path` with real behavior documentation and distinguishes them from Ansible-core's `ANSIBLE_LOG_PATH`.

##### REFERENCE
- https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/exceptions.py
- https://azure.github.io/azure-sdk/python_design.html#exceptions
- https://azure.github.io/azure-sdk/python_implementation.html#logging
- https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/azlogging.py