### PR TITLE
Add support for storage profile

### DIFF
--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -682,6 +682,53 @@ options:
                     - Unmanaged
                     - SecurityPatch
                     - NodeImage
+    storage_profile:
+        description:
+            - Storage profile for the AKS cluster.
+            - Defines the CSI drivers and snapshot controller enabled on the cluster.
+        type: dict
+        version_added: '4.0.0'
+        suboptions:
+            disk_csi_driver:
+                description:
+                    - Azure Disk CSI driver configuration.
+                type: dict
+                suboptions:
+                    enabled:
+                        description:
+                            - Whether the Azure Disk CSI driver is enabled.
+                        type: bool
+                        required: false
+            file_csi_driver:
+                description:
+                    - Azure File CSI driver configuration.
+                type: dict
+                suboptions:
+                    enabled:
+                        description:
+                            - Whether the Azure File CSI driver is enabled.
+                        type: bool
+                        required: false
+            snapshot_controller:
+                description:
+                    - Snapshot controller configuration.
+                type: dict
+                suboptions:
+                    enabled:
+                        description:
+                            - Whether the snapshot controller is enabled.
+                        type: bool
+                        required: false
+            blob_csi_driver:
+                description:
+                    - Azure Blob CSI driver configuration.
+                type: dict
+                suboptions:
+                    enabled:
+                        description:
+                            - Whether the Azure Blob CSI driver is enabled.
+                        type: bool
+                        required: false
 extends_documentation_fragment:
     - azure.azcollection.azure
     - azure.azcollection.azure_tags
@@ -1025,6 +1072,7 @@ def create_aks_dict(aks):
         windows_profile=create_windows_profile_dict(aks.windows_profile),
         pod_identity_profile=create_pod_identity_profile(aks.pod_identity_profile.as_dict()) if aks.pod_identity_profile else None,
         security_profile=aks.security_profile.as_dict() if aks.security_profile else None,
+        storage_profile=aks.storage_profile.as_dict() if aks.storage_profile else None
     )
 
 
@@ -1522,6 +1570,35 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                     ),
                 )
             ),
+            storage_profile=dict(
+                type='dict',
+                options=dict(
+                    disk_csi_driver=dict(
+                        type='dict',
+                        options=dict(
+                            enabled=dict(type='bool', required=False),
+                        )
+                    ),
+                    file_csi_driver=dict(
+                        type='dict',
+                        options=dict(
+                            enabled=dict(type='bool', required=False),
+                        )
+                    ),
+                    snapshot_controller=dict(
+                        type='dict',
+                        options=dict(
+                            enabled=dict(type='bool', required=False),
+                        )
+                    ),
+                    blob_csi_driver=dict(
+                        type='dict',
+                        options=dict(
+                            enabled=dict(type='bool', required=False),
+                        )
+                    ),
+                )
+            ),
         )
 
         self.resource_group = None
@@ -1823,6 +1900,11 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                         to_be_updated = True
                         # self.module.warn("windows_profile.admin_username cannot be updated")
 
+                    if not self.default_compare({}, self.storage_profile, response['storage_profile'], '', dict(compare=[])):
+                        to_be_updated = True
+                    else:
+                        self.storage_profile = response['storage_profile']
+
             if update_agentpool:
                 self.log("Need to update agentpool")
                 if not self.check_mode:
@@ -1968,6 +2050,7 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
             auto_upgrade_profile=auto_upgrade_profile,
             disable_local_accounts=self.disable_local_accounts,
             security_profile=security_profile,
+            storage_profile=self.storage_profile,
         )
 
         # self.log("service_principal_profile : {0}".format(parameters.service_principal_profile))

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -2050,7 +2050,7 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
             auto_upgrade_profile=auto_upgrade_profile,
             disable_local_accounts=self.disable_local_accounts,
             security_profile=security_profile,
-            storage_profile=self.managedcluster_models.ManagedClusterStorageProfile(**self.storage_profile) if self.storage_profile else None,
+            storage_profile=self.create_cluster_storage_profile_instance(self.storage_profile),
         )
 
         # self.log("service_principal_profile : {0}".format(parameters.service_principal_profile))
@@ -2228,6 +2228,9 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
 
     def create_aad_profile_instance(self, aad):
         return self.managedcluster_models.ManagedClusterAADProfile(**aad) if aad else None
+
+    def create_cluster_storage_profile_instance(self, storage):
+        return self.managedcluster_models.ManagedClusterStorageProfile(**storage) if storage else None
 
     def create_addon_profile_instance(self, addon):
         result = dict()

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -2050,7 +2050,7 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
             auto_upgrade_profile=auto_upgrade_profile,
             disable_local_accounts=self.disable_local_accounts,
             security_profile=security_profile,
-            storage_profile=self.storage_profile,
+            storage_profile=self.managedcluster_models.ManagedClusterStorageProfile(**self.storage_profile) if self.storage_profile else None,
         )
 
         # self.log("service_principal_profile : {0}".format(parameters.service_principal_profile))

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -805,6 +805,154 @@
           - "fact.aks | length == 1"
           - fact.aks[0].kube_config == output.kube_config
 
+    - name: Update the AKS instance with blob driver storage profile 
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            enable_auto_scaling: true
+            max_count: 6
+            min_count: 1
+            max_pods: 42
+            availability_zones:
+              - 1
+          - name: default2
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+        storage_profile:
+          disk_csi_driver:
+            enabled: true
+          blob_csi_driver:
+            enabled: true
+      register: output
+
+    - name: Assert the AKS storage profile is active
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.provisioning_state == 'Succeeded'
+          - output.storage_profile.disk_csi_driver.enabled == true
+          - output.storage_profile.file_csi_driver.enabled == true
+          - output.storage_profile.snapshot_controller.enabled == true
+          - output.storage_profile.blob_csi_driver.enabled == true
+
+    - name: Update the AKS instance with blob driver storage profile (idempontent)
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            enable_auto_scaling: true
+            max_count: 6
+            min_count: 1
+            max_pods: 42
+            availability_zones:
+              - 1
+          - name: default2
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+        storage_profile:
+          disk_csi_driver:
+            enabled: true
+          blob_csi_driver:
+            enabled: true
+          file_csi_driver:
+            enabled: true
+      register: output
+
+    - name: Assert the AKS storage profile is idempontent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Update the AKS instance disable blob driver
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ version1.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+          client_secret: "{{ azure_secret }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            enable_auto_scaling: true
+            max_count: 6
+            min_count: 1
+            max_pods: 42
+            availability_zones:
+              - 1
+          - name: default2
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+        storage_profile:
+          blob_csi_driver:
+            enabled: false
+      register: output
+
+    - name: Assert the AKS storage profile is inactive for blob driver only
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.provisioning_state == 'Succeeded'
+          - output.storage_profile.disk_csi_driver.enabled == true
+          - output.storage_profile.file_csi_driver.enabled == true
+          - output.storage_profile.snapshot_controller.enabled == true
+          - output.storage_profile.blob_csi_driver.enabled == false
+
     - name: Create AKS with Spot agent pool
       azure.azcollection.azure_rm_aks:
         name: "aks{{ rpfx }}-spot"


### PR DESCRIPTION
##### SUMMARY
Add support for configuring the AKS `storage_profile` in the `azure_rm_aks` module.

This includes support for the following storage components:
- Azure Disk CSI Driver
- Azure File CSI Driver
- Snapshot Controller
- Azure Blob CSI Driver

The storage profile is also returned in the module output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_aks

##### ADDITIONAL INFORMATION
The following configuration is now supported:

```yaml
storage_profile:
  disk_csi_driver:
    enabled: true
  file_csi_driver:
    enabled: true
  snapshot_controller:
    enabled: true
  blob_csi_driver:
    enabled: true
```