### PR TITLE
New Module: Add Azure Container Apps modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -64,6 +64,10 @@ action_groups:
     - azure.azcollection.azure_rm_cognitivesearch_info
     - azure.azcollection.azure_rm_cognitiveservicesaccount
     - azure.azcollection.azure_rm_cognitiveservicesaccount_info
+    - azure.azcollection.azure_rm_containerapp
+    - azure.azcollection.azure_rm_containerapp_info
+    - azure.azcollection.azure_rm_containerappenvironment
+    - azure.azcollection.azure_rm_containerappenvironment_info
     - azure.azcollection.azure_rm_containerinstance
     - azure.azcollection.azure_rm_containerinstance_info
     - azure.azcollection.azure_rm_containerregistry

--- a/plugins/module_utils/azure_rm_common.py
+++ b/plugins/module_utils/azure_rm_common.py
@@ -265,6 +265,7 @@ try:
     from azure.mgmt.mysqlflexibleservers import MySQLManagementClient as MySQLFlexibleManagementClient
     from azure.mgmt.containerregistry import ContainerRegistryManagementClient
     from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+    from azure.mgmt.appcontainers import ContainerAppsAPIClient
     from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     import azure.mgmt.loganalytics.models as LogAnalyticsModels
     from azure.mgmt.automation import AutomationClient
@@ -425,6 +426,7 @@ class AzureRMModuleBase(object):
         self._containerinstance_client = None
         self._containerservice_client = None
         self._managedcluster_client = None
+        self._containerapps_client = None
         self._traffic_manager_management_client = None
         self._monitor_autoscale_settings_client = None
         self._monitor_log_profiles_client = None
@@ -1339,6 +1341,15 @@ class AzureRMModuleBase(object):
                                                                       api_version='2023-05-01')
 
         return self._containerinstance_client
+
+    @property
+    def containerapps_client(self):
+        self.log('Getting Container Apps client')
+        if not self._containerapps_client:
+            self._containerapps_client = self.get_mgmt_svc_client(ContainerAppsAPIClient,
+                                                                  base_url=self._cloud_environment.endpoints.resource_manager,
+                                                                  api_version='2024-03-01')
+        return self._containerapps_client
 
     @property
     def marketplace_client(self):

--- a/plugins/modules/azure_rm_containerapp.py
+++ b/plugins/modules/azure_rm_containerapp.py
@@ -546,17 +546,6 @@ import copy
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 
-def _normalize(obj):
-    """
-    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model.
-    """
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        return obj
-    return as_attribute_dict(obj, exclude_readonly=False)
-
-
 def _strip_write_only(parameters):
     """
     Remove fields that Azure never returns on read (secret values, etc.)
@@ -922,8 +911,9 @@ class AzureRMContainerApp(AzureRMModuleBaseExt):
                 patch_support=True,
             )
             if identity_body is not None:
-                self.parameters['identity'] = identity_body
-                self.update_parameters['identity'] = identity_body
+                identity_dict = as_attribute_dict(identity_body, exclude_readonly=False) if identity_body else None
+                self.parameters['identity'] = identity_dict
+                self.update_parameters['identity'] = identity_dict
 
         changed = False
         if old_response is None:
@@ -1088,7 +1078,7 @@ class AzureRMContainerApp(AzureRMModuleBaseExt):
     def format_item(self, item):
         if item is None:
             return None
-        normalized = _normalize(item)
+        normalized = as_attribute_dict(item, exclude_readonly=False)
         if normalized.get('id'):
             parsed = self.parse_resource_to_dict(normalized['id'])
             normalized['resource_group'] = parsed.get('resource_group')

--- a/plugins/modules/azure_rm_containerapp.py
+++ b/plugins/modules/azure_rm_containerapp.py
@@ -1,0 +1,1105 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_containerapp
+version_added: "4.0.0"
+short_description: Manage Azure Container Apps
+description:
+    - Create, update, delete, start and stop an Azure Container App.
+    - Container Apps run in a Managed Environment created with M(azure.azcollection.azure_rm_containerappenvironment).
+
+options:
+    resource_group:
+        description:
+            - The name of the resource group.
+        required: true
+        type: str
+    name:
+        description:
+            - Name of the container app.
+        required: true
+        type: str
+    location:
+        description:
+            - Resource location. If not set, location from the resource group will be used.
+        type: str
+    environment_id:
+        description:
+            - Full resource ID of the parent managed environment.
+            - Required when creating a container app.
+        type: str
+    workload_profile_name:
+        description:
+            - Workload profile name to pin the app to. Must exist on the parent environment.
+        type: str
+    identity:
+        description:
+            - Managed identity assigned to the container app.
+        type: dict
+        suboptions:
+            type:
+                description:
+                    - Type of the managed identity.
+                type: str
+                choices:
+                    - SystemAssigned
+                    - UserAssigned
+                    - 'SystemAssigned, UserAssigned'
+                    - None
+                default: None
+            user_assigned_identities:
+                description:
+                    - User-assigned managed identities.
+                type: dict
+                default: {}
+                suboptions:
+                    id:
+                        description:
+                            - List of resource IDs of user-assigned managed identities.
+                        type: list
+                        elements: str
+                        default: []
+                    append:
+                        description:
+                            - Whether to append the provided identities to any already assigned.
+                        type: bool
+                        default: true
+    active_revisions_mode:
+        description:
+            - Active revisions mode for the container app.
+        type: str
+        choices:
+            - Single
+            - Multiple
+    secrets:
+        description:
+            - List of secrets exposed to the container app.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description: Secret name.
+                type: str
+                required: true
+            value:
+                description: Secret value.
+                type: str
+            key_vault_url:
+                description: Azure Key Vault URL pointing at the secret.
+                type: str
+            identity:
+                description: Resource ID of the managed identity used to access the Key Vault secret. Use C(system) for system-assigned.
+                type: str
+    registries:
+        description:
+            - Container image registries the container app pulls from.
+        type: list
+        elements: dict
+        suboptions:
+            server:
+                description: Container registry server (for example C(myacr.azurecr.io)).
+                type: str
+                required: true
+            username:
+                description: Registry username. Omit when using managed identity.
+                type: str
+            password_secret_ref:
+                description: Name of the secret in I(secrets) that contains the registry password.
+                type: str
+            identity:
+                description: Resource ID of a user-assigned managed identity, or C(system) for system-assigned.
+                type: str
+    ingress:
+        description:
+            - Ingress configuration for the container app.
+        type: dict
+        suboptions:
+            external:
+                description: Whether ingress is externally reachable.
+                type: bool
+            target_port:
+                description: Container port that ingress forwards to.
+                type: int
+            exposed_port:
+                description: Exposed TCP port (transport C(tcp) only).
+                type: int
+            transport:
+                description: Transport protocol.
+                type: str
+                choices: [auto, http, http2, tcp]
+            allow_insecure:
+                description: Allow insecure HTTP connections.
+                type: bool
+            client_certificate_mode:
+                description: Client certificate mode.
+                type: str
+                choices: [ignore, accept, require]
+            traffic:
+                description: Traffic weights across revisions.
+                type: list
+                elements: dict
+                suboptions:
+                    revision_name:
+                        description: Target revision name.
+                        type: str
+                    weight:
+                        description: Traffic weight assigned to the revision.
+                        type: int
+                    label:
+                        description: Associates a traffic label with a revision.
+                        type: str
+                    latest_revision:
+                        description: Whether the traffic weight targets the latest revision.
+                        type: bool
+            custom_domains:
+                description: Custom domain bindings.
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Domain hostname.
+                        type: str
+                        required: true
+                    binding_type:
+                        description: Binding type.
+                        type: str
+                        choices: [Disabled, SniEnabled]
+                    certificate_id:
+                        description: Resource ID of the certificate.
+                        type: str
+            ip_security_restrictions:
+                description: IP-based restrictions.
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Rule name.
+                        type: str
+                        required: true
+                    description:
+                        description: Rule description.
+                        type: str
+                    ip_address_range:
+                        description: CIDR notation for the range.
+                        type: str
+                        required: true
+                    action:
+                        description: Allow or Deny.
+                        type: str
+                        choices: [Allow, Deny]
+                        required: true
+            cors_policy:
+                description: CORS policy pass-through as an SDK-shaped dict.
+                type: dict
+    dapr:
+        description:
+            - Dapr configuration for the container app.
+        type: dict
+        suboptions:
+            enabled:
+                description: Whether Dapr is enabled on the app.
+                type: bool
+            app_id:
+                description: Dapr application identifier.
+                type: str
+            app_protocol:
+                description: Protocol Dapr uses to talk to the app.
+                type: str
+                choices: [http, grpc]
+            app_port:
+                description: Port on which the app listens.
+                type: int
+            enable_api_logging:
+                description: Enables API logging for the Dapr sidecar.
+                type: bool
+            log_level:
+                description: Dapr sidecar log level.
+                type: str
+                choices: [info, debug, warn, error]
+            http_read_buffer_size:
+                description: Maximum size of HTTP header read buffer in kilobytes.
+                type: int
+            http_max_request_size:
+                description: Increasing max size of request body http server parameter in kilobytes.
+                type: int
+    max_inactive_revisions:
+        description:
+            - Maximum number of inactive revisions the app will keep.
+        type: int
+    revision_suffix:
+        description:
+            - User-friendly suffix appended to the revision name.
+        type: str
+    termination_grace_period_seconds:
+        description:
+            - Optional duration in seconds the app instance needs to terminate gracefully.
+        type: int
+    containers:
+        description:
+            - List of containers that make up the app.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description: Container name.
+                type: str
+                required: true
+            image:
+                description: Container image tag.
+                type: str
+                required: true
+            command:
+                description: Container start command.
+                type: list
+                elements: str
+            args:
+                description: Container start command arguments.
+                type: list
+                elements: str
+            env:
+                description: Container environment variables.
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Environment variable name.
+                        type: str
+                        required: true
+                    value:
+                        description: Environment variable value.
+                        type: str
+                    secret_ref:
+                        description: Name of the container-app secret to pull the value from.
+                        type: str
+            resources:
+                description: Container resource requests.
+                type: dict
+                suboptions:
+                    cpu:
+                        description: CPU cores in decimal notation.
+                        type: float
+                    memory:
+                        description: Memory (for example C(0.5Gi), C(1Gi)).
+                        type: str
+                    ephemeral_storage:
+                        description: Ephemeral storage.
+                        type: str
+            probes:
+                description: List of probes for the container.
+                type: list
+                elements: dict
+            volume_mounts:
+                description: List of volume mounts inside the container.
+                type: list
+                elements: dict
+                suboptions:
+                    volume_name:
+                        description: Volume name.
+                        type: str
+                    mount_path:
+                        description: Mount path inside the container.
+                        type: str
+                    sub_path:
+                        description: Path inside the volume.
+                        type: str
+    init_containers:
+        description:
+            - Container definitions that run before the app containers.
+            - Same schema as I(containers).
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description: Init container name.
+                type: str
+                required: true
+            image:
+                description: Init container image tag.
+                type: str
+                required: true
+            command:
+                description: Init container start command.
+                type: list
+                elements: str
+            args:
+                description: Init container start command arguments.
+                type: list
+                elements: str
+            env:
+                description: Init container environment variables.
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Environment variable name.
+                        type: str
+                        required: true
+                    value:
+                        description: Environment variable value.
+                        type: str
+                    secret_ref:
+                        description: Name of the container-app secret to pull the value from.
+                        type: str
+            resources:
+                description: Init container resource requests.
+                type: dict
+                suboptions:
+                    cpu:
+                        description: CPU cores in decimal notation.
+                        type: float
+                    memory:
+                        description: Memory (for example C(0.5Gi), C(1Gi)).
+                        type: str
+                    ephemeral_storage:
+                        description: Ephemeral storage.
+                        type: str
+            volume_mounts:
+                description: List of volume mounts inside the init container.
+                type: list
+                elements: dict
+                suboptions:
+                    volume_name:
+                        description: Volume name.
+                        type: str
+                    mount_path:
+                        description: Mount path inside the container.
+                        type: str
+                    sub_path:
+                        description: Path inside the volume.
+                        type: str
+    scale:
+        description:
+            - Scaling configuration.
+        type: dict
+        suboptions:
+            min_replicas:
+                description: Minimum replica count.
+                type: int
+            max_replicas:
+                description: Maximum replica count.
+                type: int
+            cooldown_period:
+                description: Cooldown period in seconds after scaling.
+                type: int
+            polling_interval:
+                description: Interval in seconds between scaling decisions.
+                type: int
+            rules:
+                description:
+                    - List of KEDA scaling rules.
+                    - Each item follows the SDK ScaleRule model shape.
+                type: list
+                elements: dict
+    volumes:
+        description:
+            - List of volumes for containers to mount.
+        type: list
+        elements: dict
+    status:
+        description:
+            - Runtime action to apply after any create/update.
+            - C(start) starts a stopped app. C(stop) stops a running app.
+        type: str
+        choices:
+            - start
+            - stop
+    state:
+        description:
+            - Assert the state of the container app.
+        default: present
+        type: str
+        choices:
+            - present
+            - absent
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+    - azure.azcollection.azure_tags
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Create minimal container app
+  azure.azcollection.azure_rm_containerapp:
+    resource_group: myResourceGroup
+    name: hello
+    environment_id: "/subscriptions/xxxx/resourceGroups/myResourceGroup/providers/Microsoft.App/managedEnvironments/myenv"
+    ingress:
+      external: true
+      target_port: 80
+      transport: auto
+    containers:
+      - name: hello
+        image: mcr.microsoft.com/k8se/quickstart:latest
+        resources:
+          cpu: 0.25
+          memory: 0.5Gi
+    scale:
+      min_replicas: 0
+      max_replicas: 3
+
+- name: Container app pulling from ACR with user-assigned managed identity
+  azure.azcollection.azure_rm_containerapp:
+    resource_group: myResourceGroup
+    name: private-app
+    environment_id: "{{ env_id }}"
+    identity:
+      type: UserAssigned
+      user_assigned_identities:
+        id:
+          - "/subscriptions/xxxx/resourceGroups/myResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aca-pull"
+    registries:
+      - server: myacr.azurecr.io
+        identity: "/subscriptions/xxxx/resourceGroups/myResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aca-pull"
+    containers:
+      - name: app
+        image: myacr.azurecr.io/hello:1.0
+        resources:
+          cpu: 0.5
+          memory: 1Gi
+
+- name: Stop the container app
+  azure.azcollection.azure_rm_containerapp:
+    resource_group: myResourceGroup
+    name: hello
+    status: stop
+
+- name: Delete the container app
+  azure.azcollection.azure_rm_containerapp:
+    resource_group: myResourceGroup
+    name: hello
+    state: absent
+'''
+
+RETURN = '''
+state:
+    description:
+        - Current state of the container app.
+    returned: always
+    type: complex
+    contains:
+        id:
+            description: Fully qualified resource ID.
+            type: str
+            returned: always
+        name:
+            description: Container app name.
+            type: str
+            returned: always
+        location:
+            description: Resource location.
+            type: str
+            returned: always
+        provisioning_state:
+            description: Provisioning state.
+            type: str
+            returned: always
+        latest_revision_name:
+            description: Latest revision name of the app.
+            type: str
+            returned: always
+        latest_revision_fqdn:
+            description: FQDN of the latest revision.
+            type: str
+            returned: always
+        configuration:
+            description: App configuration.
+            type: dict
+            returned: always
+        template:
+            description: App template with containers and scaling.
+            type: dict
+            returned: always
+'''
+
+try:
+    from azure.core.polling import LROPoller
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
+    from azure.mgmt.appcontainers.models import (
+        ContainerApp, Configuration, Template, Ingress, Dapr, Scale, ScaleRule,
+        HttpScaleRule, TcpScaleRule, QueueScaleRule, CustomScaleRule,
+        ScaleRuleAuth, Container, InitContainer, ContainerResources,
+        ContainerAppProbe, ContainerAppProbeHttpGet, ContainerAppProbeTcpSocket,
+        ContainerAppProbeHttpGetHttpHeadersItem, EnvironmentVar, VolumeMount,
+        Volume, Secret, RegistryCredentials, TrafficWeight, CustomDomain,
+        IpSecurityRestrictionRule, CorsPolicy, IngressStickySessions,
+        IngressPortMapping, ServiceBind,
+        ManagedServiceIdentity, UserAssignedIdentity,
+    )
+except ImportError:
+    pass
+
+import copy
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+
+
+def _normalize(obj):
+    """
+    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    return as_attribute_dict(obj, exclude_readonly=False)
+
+
+def _strip_write_only(parameters):
+    """
+    Remove fields that Azure never returns on read (secret values, etc.)
+    so idempotence compare against the fetched state does not always report a
+    diff.
+    """
+    sanitized = copy.deepcopy(parameters)
+    config = sanitized.get('configuration') or {}
+    for secret in (config.get('secrets') or []):
+        secret.pop('value', None)
+    return sanitized
+
+
+def _clean(model_cls, data):
+    """Instantiate ``model_cls(**data)`` skipping ``None`` values so we do not
+    override server defaults with explicit nulls.
+    """
+    if data is None:
+        return None
+    return model_cls(**{k: v for k, v in data.items() if v is not None})
+
+
+def _build_ingress(ingress):
+    if ingress is None:
+        return None
+    data = dict(ingress)
+    if data.get('traffic') is not None:
+        data['traffic'] = [_clean(TrafficWeight, t) for t in data['traffic']]
+    if data.get('custom_domains') is not None:
+        data['custom_domains'] = [_clean(CustomDomain, c) for c in data['custom_domains']]
+    if data.get('ip_security_restrictions') is not None:
+        data['ip_security_restrictions'] = [_clean(IpSecurityRestrictionRule, r) for r in data['ip_security_restrictions']]
+    if data.get('cors_policy') is not None:
+        data['cors_policy'] = _clean(CorsPolicy, data['cors_policy'])
+    if data.get('sticky_sessions') is not None:
+        data['sticky_sessions'] = _clean(IngressStickySessions, data['sticky_sessions'])
+    if data.get('additional_port_mappings') is not None:
+        data['additional_port_mappings'] = [_clean(IngressPortMapping, p) for p in data['additional_port_mappings']]
+    return _clean(Ingress, data)
+
+
+def _build_probe(probe):
+    if probe is None:
+        return None
+    data = dict(probe)
+    hg = data.get('http_get')
+    if hg is not None:
+        hg_data = dict(hg)
+        if hg_data.get('http_headers') is not None:
+            hg_data['http_headers'] = [_clean(ContainerAppProbeHttpGetHttpHeadersItem, h) for h in hg_data['http_headers']]
+        data['http_get'] = _clean(ContainerAppProbeHttpGet, hg_data)
+    if data.get('tcp_socket') is not None:
+        data['tcp_socket'] = _clean(ContainerAppProbeTcpSocket, data['tcp_socket'])
+    return _clean(ContainerAppProbe, data)
+
+
+def _build_container(c, is_init=False):
+    if c is None:
+        return None
+    data = dict(c)
+    if data.get('env') is not None:
+        data['env'] = [_clean(EnvironmentVar, e) for e in data['env']]
+    if data.get('resources') is not None:
+        data['resources'] = _clean(ContainerResources, data['resources'])
+    if data.get('volume_mounts') is not None:
+        data['volume_mounts'] = [_clean(VolumeMount, v) for v in data['volume_mounts']]
+    if data.get('probes') is not None:
+        data['probes'] = [_build_probe(p) for p in data['probes']]
+    return _clean(InitContainer if is_init else Container, data)
+
+
+def _build_scale_rule(rule):
+    if rule is None:
+        return None
+    data = dict(rule)
+    for shape, cls in (('http', HttpScaleRule), ('tcp', TcpScaleRule),
+                       ('azure_queue', QueueScaleRule), ('custom', CustomScaleRule)):
+        if data.get(shape) is not None:
+            inner = dict(data[shape])
+            if inner.get('auth') is not None:
+                inner['auth'] = [_clean(ScaleRuleAuth, a) for a in inner['auth']]
+            data[shape] = _clean(cls, inner)
+    return _clean(ScaleRule, data)
+
+
+def _build_scale(scale):
+    if scale is None:
+        return None
+    data = dict(scale)
+    if data.get('rules') is not None:
+        data['rules'] = [_build_scale_rule(r) for r in data['rules']]
+    return _clean(Scale, data)
+
+
+def _build_configuration(config):
+    if config is None:
+        return None
+    data = dict(config)
+    if data.get('secrets') is not None:
+        data['secrets'] = [_clean(Secret, s) for s in data['secrets']]
+    if data.get('registries') is not None:
+        data['registries'] = [_clean(RegistryCredentials, r) for r in data['registries']]
+    if data.get('ingress') is not None:
+        data['ingress'] = _build_ingress(data['ingress'])
+    if data.get('dapr') is not None:
+        data['dapr'] = _clean(Dapr, data['dapr'])
+    return _clean(Configuration, data)
+
+
+def _build_template(template):
+    if template is None:
+        return None
+    data = dict(template)
+    if data.get('containers') is not None:
+        data['containers'] = [_build_container(c, is_init=False) for c in data['containers']]
+    if data.get('init_containers') is not None:
+        data['init_containers'] = [_build_container(c, is_init=True) for c in data['init_containers']]
+    if data.get('scale') is not None:
+        data['scale'] = _build_scale(data['scale'])
+    if data.get('volumes') is not None:
+        data['volumes'] = [_clean(Volume, v) for v in data['volumes']]
+    if data.get('service_binds') is not None:
+        data['service_binds'] = [_clean(ServiceBind, s) for s in data['service_binds']]
+    return _clean(Template, data)
+
+
+def _build_identity_model(identity):
+    if identity is None:
+        return None
+    data = dict(identity)
+    if data.get('user_assigned_identities') is not None:
+        data['user_assigned_identities'] = {
+            k: _clean(UserAssignedIdentity, v) if isinstance(v, dict) else v
+            for k, v in data['user_assigned_identities'].items()
+        }
+    return _clean(ManagedServiceIdentity, data)
+
+
+def _build_app_model(params):
+    """Construct a ``ContainerApp`` model tree from a snake_case dict.
+
+    ``azure-mgmt-appcontainers`` 5.0.0 typed models require explicit model
+    instances so the ARM wire payload nests resource fields under
+    ``properties`` with correct camelCase keys (mirrors ``azure_rm_keyvault``
+    14.0.1 pattern).
+    """
+    return ContainerApp(
+        location=params.get('location'),
+        tags=params.get('tags'),
+        identity=_build_identity_model(params.get('identity')),
+        kind=params.get('kind'),
+        managed_environment_id=params.get('managed_environment_id'),
+        workload_profile_name=params.get('workload_profile_name'),
+        configuration=_build_configuration(params.get('configuration')),
+        template=_build_template(params.get('template')),
+    )
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+SECRET_SPEC = dict(
+    name=dict(type='str', required=True),
+    value=dict(type='str', no_log=True),
+    key_vault_url=dict(type='str', no_log=False),
+    identity=dict(type='str'),
+)
+
+
+REGISTRY_SPEC = dict(
+    server=dict(type='str', required=True),
+    username=dict(type='str'),
+    password_secret_ref=dict(type='str', no_log=False),
+    identity=dict(type='str'),
+)
+
+
+TRAFFIC_SPEC = dict(
+    revision_name=dict(type='str'),
+    weight=dict(type='int'),
+    label=dict(type='str'),
+    latest_revision=dict(type='bool'),
+)
+
+
+CUSTOM_DOMAIN_SPEC = dict(
+    name=dict(type='str', required=True),
+    binding_type=dict(type='str', choices=['Disabled', 'SniEnabled']),
+    certificate_id=dict(type='str'),
+)
+
+
+IP_RESTRICTION_SPEC = dict(
+    name=dict(type='str', required=True),
+    description=dict(type='str'),
+    ip_address_range=dict(type='str', required=True),
+    action=dict(type='str', choices=['Allow', 'Deny'], required=True),
+)
+
+
+INGRESS_SPEC = dict(
+    external=dict(type='bool'),
+    target_port=dict(type='int'),
+    exposed_port=dict(type='int'),
+    transport=dict(type='str', choices=['auto', 'http', 'http2', 'tcp']),
+    allow_insecure=dict(type='bool'),
+    client_certificate_mode=dict(type='str', choices=['ignore', 'accept', 'require']),
+    traffic=dict(type='list', elements='dict', options=TRAFFIC_SPEC),
+    custom_domains=dict(type='list', elements='dict', options=CUSTOM_DOMAIN_SPEC),
+    ip_security_restrictions=dict(type='list', elements='dict', options=IP_RESTRICTION_SPEC),
+    cors_policy=dict(type='dict'),
+)
+
+
+DAPR_SPEC = dict(
+    enabled=dict(type='bool'),
+    app_id=dict(type='str'),
+    app_protocol=dict(type='str', choices=['http', 'grpc']),
+    app_port=dict(type='int'),
+    enable_api_logging=dict(type='bool'),
+    log_level=dict(type='str', choices=['info', 'debug', 'warn', 'error']),
+    http_read_buffer_size=dict(type='int'),
+    http_max_request_size=dict(type='int'),
+)
+
+
+ENV_VAR_SPEC = dict(
+    name=dict(type='str', required=True),
+    value=dict(type='str'),
+    secret_ref=dict(type='str', no_log=False),
+)
+
+
+RESOURCES_SPEC = dict(
+    cpu=dict(type='float'),
+    memory=dict(type='str'),
+    ephemeral_storage=dict(type='str'),
+)
+
+
+VOLUME_MOUNT_SPEC = dict(
+    volume_name=dict(type='str'),
+    mount_path=dict(type='str'),
+    sub_path=dict(type='str'),
+)
+
+
+CONTAINER_SPEC = dict(
+    name=dict(type='str', required=True),
+    image=dict(type='str', required=True),
+    command=dict(type='list', elements='str'),
+    args=dict(type='list', elements='str'),
+    env=dict(type='list', elements='dict', options=ENV_VAR_SPEC),
+    resources=dict(type='dict', options=RESOURCES_SPEC),
+    probes=dict(type='list', elements='dict'),
+    volume_mounts=dict(type='list', elements='dict', options=VOLUME_MOUNT_SPEC),
+)
+
+
+INIT_CONTAINER_SPEC = dict(
+    name=dict(type='str', required=True),
+    image=dict(type='str', required=True),
+    command=dict(type='list', elements='str'),
+    args=dict(type='list', elements='str'),
+    env=dict(type='list', elements='dict', options=ENV_VAR_SPEC),
+    resources=dict(type='dict', options=RESOURCES_SPEC),
+    volume_mounts=dict(type='list', elements='dict', options=VOLUME_MOUNT_SPEC),
+)
+
+
+SCALE_SPEC = dict(
+    min_replicas=dict(type='int'),
+    max_replicas=dict(type='int'),
+    cooldown_period=dict(type='int'),
+    polling_interval=dict(type='int'),
+    rules=dict(type='list', elements='dict'),
+)
+
+
+CONFIG_KEYS = ('secrets', 'active_revisions_mode', 'registries', 'ingress', 'dapr', 'max_inactive_revisions')
+TEMPLATE_KEYS = ('revision_suffix', 'termination_grace_period_seconds', 'containers', 'init_containers', 'scale', 'volumes')
+
+
+class AzureRMContainerApp(AzureRMModuleBaseExt):
+    """Manage Azure Container Apps."""
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            name=dict(type='str', required=True),
+            location=dict(type='str'),
+            environment_id=dict(type='str'),
+            workload_profile_name=dict(type='str'),
+            identity=dict(type='dict', options=self.managed_identity_multiple_spec),
+            active_revisions_mode=dict(type='str', choices=['Single', 'Multiple']),
+            secrets=dict(type='list', elements='dict', options=SECRET_SPEC, no_log=False),
+            registries=dict(type='list', elements='dict', options=REGISTRY_SPEC),
+            ingress=dict(type='dict', options=INGRESS_SPEC),
+            dapr=dict(type='dict', options=DAPR_SPEC),
+            max_inactive_revisions=dict(type='int'),
+            revision_suffix=dict(type='str'),
+            termination_grace_period_seconds=dict(type='int'),
+            containers=dict(type='list', elements='dict', options=CONTAINER_SPEC),
+            init_containers=dict(type='list', elements='dict', options=INIT_CONTAINER_SPEC),
+            scale=dict(type='dict', options=SCALE_SPEC),
+            volumes=dict(type='list', elements='dict'),
+            status=dict(type='str', choices=['start', 'stop']),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.location = None
+        self.tags = None
+        self.state = None
+        self.status = None
+        self.identity = None
+
+        self.parameters = dict()
+        self.update_parameters = dict()
+
+        self.results = dict(changed=False)
+        self.to_do = Actions.NoAction
+
+        self._managed_identity = None
+
+        super(AzureRMContainerApp, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=True,
+        )
+
+    @property
+    def managed_identity(self):
+        if not self._managed_identity:
+            self._managed_identity = {
+                "identity": ManagedServiceIdentity,
+                "user_assigned": UserAssignedIdentity,
+            }
+        return self._managed_identity
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
+            elif kwargs[key] is not None:
+                self._assign(key, kwargs[key])
+
+        resource_group = self.get_resource_group(self.resource_group)
+        if self.location is None:
+            self.location = resource_group.location
+        self.parameters['location'] = self.location
+
+        old_response = self.get_resource()
+
+        identity_changed = False
+        if self.identity is not None:
+            curr_identity = old_response.get('identity') if old_response else None
+            identity_changed, identity_body = self.update_managed_identity(
+                curr_identity=curr_identity,
+                new_identity=self.identity,
+                patch_support=True,
+            )
+            if identity_body is not None:
+                self.parameters['identity'] = identity_body
+                self.update_parameters['identity'] = identity_body
+
+        changed = False
+        if old_response is None:
+            if self.state == 'present':
+                self.to_do = Actions.Create
+                changed = True
+        else:
+            if self.state == 'absent':
+                self.to_do = Actions.Delete
+                changed = True
+            else:
+                if identity_changed:
+                    changed = True
+                    self.to_do = Actions.Update
+
+                update_tags, self.update_parameters['tags'] = self.update_tags(old_response.get('tags'))
+                if update_tags:
+                    changed = True
+                    self.to_do = Actions.Update
+
+                # Compare configuration + template payloads against the fetched state.
+                # Strip write-only fields (secret values) so they never trigger a false diff.
+                sanitized = _strip_write_only(self.parameters)
+                for section in ('configuration', 'template'):
+                    if section in sanitized and not self.default_compare(
+                            {}, sanitized.get(section), old_response.get(section), '', dict(compare=[])):
+                        changed = True
+                        self.to_do = Actions.Update
+
+                # environment id / workload profile are stored in parameters using their
+                # ARM key names — compare against those directly.
+                for arm_key in ('managed_environment_id', 'workload_profile_name'):
+                    desired = self.parameters.get(arm_key)
+                    if desired is not None and desired != old_response.get(arm_key):
+                        changed = True
+                        self.to_do = Actions.Update
+
+        if self.to_do in (Actions.Create, Actions.Update):
+            if not self.check_mode:
+                self.create_update_resource()
+                self.results['state'] = self.get_resource()
+            else:
+                self.results['state'] = old_response or self.parameters
+        elif self.to_do == Actions.Delete:
+            if not self.check_mode:
+                self.delete_resource()
+            self.results['state'] = dict()
+        else:
+            self.results['state'] = old_response or dict()
+
+        if self.status and self.state == 'present' and self.to_do != Actions.Delete:
+            # Use the freshly-fetched state so start/stop is idempotent across create+status runs.
+            current_state = self.results.get('state') or self.get_resource()
+            performed = self.apply_status(current_state)
+            if performed:
+                changed = True
+                if not self.check_mode:
+                    self.results['state'] = self.get_resource() or self.results['state']
+
+        self.results['changed'] = changed
+        return self.results
+
+    def _assign(self, key, value):
+        if key in CONFIG_KEYS:
+            self.parameters.setdefault('configuration', dict())[key] = value
+            self.update_parameters.setdefault('configuration', dict())[key] = value
+        elif key in TEMPLATE_KEYS:
+            self.parameters.setdefault('template', dict())[key] = value
+            self.update_parameters.setdefault('template', dict())[key] = value
+        elif key in ('environment_id', 'workload_profile_name'):
+            arm_key = 'managed_environment_id' if key == 'environment_id' else key
+            self.parameters[arm_key] = value
+            if key == 'workload_profile_name':
+                self.update_parameters[arm_key] = value
+        else:
+            self.parameters[key] = value
+
+    def create_update_resource(self):
+        self.log("Creating / updating container app {0}".format(self.name))
+        try:
+            if self.to_do == Actions.Create:
+                self.parameters['tags'] = self.tags
+                envelope = _build_app_model(self.parameters)
+                response = self.containerapps_client.container_apps.begin_create_or_update(
+                    resource_group_name=self.resource_group,
+                    container_app_name=self.name,
+                    container_app_envelope=envelope,
+                )
+            else:
+                envelope = _build_app_model(self.update_parameters)
+                response = self.containerapps_client.container_apps.begin_update(
+                    resource_group_name=self.resource_group,
+                    container_app_name=self.name,
+                    container_app_envelope=envelope,
+                )
+            if isinstance(response, LROPoller):
+                response = self.get_poller_result(response)
+        except Exception as exc:
+            self.fail("Error creating/updating container app {0}: {1}".format(self.name, str(exc)))
+        return self.format_item(response)
+
+    def delete_resource(self):
+        self.log("Deleting container app {0}".format(self.name))
+        try:
+            response = self.containerapps_client.container_apps.begin_delete(
+                resource_group_name=self.resource_group,
+                container_app_name=self.name,
+            )
+            if isinstance(response, LROPoller):
+                self.get_poller_result(response)
+        except Exception as exc:
+            self.fail("Error deleting container app {0}: {1}".format(self.name, str(exc)))
+        return True
+
+    def get_resource(self):
+        try:
+            response = self.containerapps_client.container_apps.get(
+                resource_group_name=self.resource_group,
+                container_app_name=self.name,
+            )
+        except ResourceNotFoundError:
+            return None
+        except Exception as exc:
+            self.fail("Error retrieving container app {0}: {1}".format(self.name, str(exc)))
+        return self.format_item(response)
+
+    def apply_status(self, current_state):
+        """Run start/stop when the desired runtime state differs from the current one."""
+
+        current_running_status = None
+        if current_state:
+            current_running_status = current_state.get('running_status')
+
+        want_start = self.status == 'start'
+        want_stop = self.status == 'stop'
+
+        if want_start and current_running_status == 'Running':
+            return False
+        if want_stop and current_running_status == 'Stopped':
+            return False
+
+        if self.check_mode:
+            return True
+
+        try:
+            if want_start:
+                poller = self.containerapps_client.container_apps.begin_start(
+                    resource_group_name=self.resource_group,
+                    container_app_name=self.name,
+                )
+            else:
+                poller = self.containerapps_client.container_apps.begin_stop(
+                    resource_group_name=self.resource_group,
+                    container_app_name=self.name,
+                )
+            if isinstance(poller, LROPoller):
+                self.get_poller_result(poller)
+        except Exception as exc:
+            self.fail("Error applying status {0} to container app {1}: {2}".format(self.status, self.name, str(exc)))
+        return True
+
+    def format_item(self, item):
+        if item is None:
+            return None
+        normalized = _normalize(item)
+        if normalized.get('id'):
+            parsed = self.parse_resource_to_dict(normalized['id'])
+            normalized['resource_group'] = parsed.get('resource_group')
+        else:
+            normalized['resource_group'] = self.resource_group
+        return normalized
+
+
+def main():
+    AzureRMContainerApp()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_containerapp_info.py
+++ b/plugins/modules/azure_rm_containerapp_info.py
@@ -83,18 +83,6 @@ except ImportError:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 
-def _normalize(obj):
-    """
-    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model
-    via the Azure SDK's official ``as_attribute_dict`` backcompat helper.
-    """
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        return obj
-    return as_attribute_dict(obj, exclude_readonly=False)
-
-
 class AzureRMContainerAppInfo(AzureRMModuleBase):
     def __init__(self):
         self.module_arg_spec = dict(
@@ -134,7 +122,7 @@ class AzureRMContainerAppInfo(AzureRMModuleBase):
 
         formatted = []
         for item in items:
-            if not self._match_tags(item):
+            if self.tags and not self.has_tags(getattr(item, 'tags', None) or {}, self.tags):
                 continue
             entry = self._format(item)
             if self.show_secrets and self.name:
@@ -186,17 +174,11 @@ class AzureRMContainerAppInfo(AzureRMModuleBase):
         except Exception as exc:
             self.fail("Error listing secrets for container app {0}: {1}".format(self.name, str(exc)))
 
-        raw = _normalize(response)
+        raw = as_attribute_dict(response, exclude_readonly=False) if response else None
         return raw.get('value', []) if raw else []
 
     def _format(self, item):
-        return _normalize(item)
-
-    def _match_tags(self, item):
-        if not self.tags:
-            return True
-        tags = getattr(item, 'tags', None) or {}
-        return self.has_tags(tags, self.tags)
+        return as_attribute_dict(item, exclude_readonly=False) if item else None
 
 
 def main():

--- a/plugins/modules/azure_rm_containerapp_info.py
+++ b/plugins/modules/azure_rm_containerapp_info.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_containerapp_info
+version_added: "4.0.0"
+short_description: Get facts about Azure Container Apps
+description:
+    - Get facts about one or many Azure Container Apps.
+    - Optionally include app secrets. Secret values are considered sensitive, so C(show_secrets) defaults to C(false).
+
+options:
+    resource_group:
+        description:
+            - Name of the resource group.
+            - Required when I(name) is used.
+        type: str
+    name:
+        description:
+            - Name of the container app. When omitted, all container apps in scope are returned.
+        type: str
+    show_secrets:
+        description:
+            - When C(true) and I(name) is set, call C(list_secrets) and include the secret values in the returned payload.
+        type: bool
+        default: false
+    tags:
+        description:
+            - Limit results by providing a list of tags formatted as C(key) or C(key:value).
+        type: list
+        elements: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Get a single container app
+  azure.azcollection.azure_rm_containerapp_info:
+    resource_group: myResourceGroup
+    name: hello
+
+- name: Get a single container app with secrets
+  azure.azcollection.azure_rm_containerapp_info:
+    resource_group: myResourceGroup
+    name: hello
+    show_secrets: true
+
+- name: List all container apps in a resource group
+  azure.azcollection.azure_rm_containerapp_info:
+    resource_group: myResourceGroup
+
+- name: List all container apps in the subscription
+  azure.azcollection.azure_rm_containerapp_info:
+'''
+
+RETURN = '''
+container_apps:
+    description:
+        - List of container apps matching the filter.
+    returned: always
+    type: list
+    elements: dict
+'''
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
+except ImportError:
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+def _normalize(obj):
+    """
+    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model
+    via the Azure SDK's official ``as_attribute_dict`` backcompat helper.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    return as_attribute_dict(obj, exclude_readonly=False)
+
+
+class AzureRMContainerAppInfo(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str'),
+            name=dict(type='str'),
+            show_secrets=dict(type='bool', default=False),
+            tags=dict(type='list', elements='str'),
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.show_secrets = False
+        self.tags = None
+
+        self.results = dict(changed=False, container_apps=[])
+
+        super(AzureRMContainerAppInfo, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.name and not self.resource_group:
+            self.fail("resource_group is required when name is specified")
+
+        if self.name:
+            items = self._get()
+        elif self.resource_group:
+            items = self._list_by_rg()
+        else:
+            items = self._list_by_sub()
+
+        formatted = []
+        for item in items:
+            if not self._match_tags(item):
+                continue
+            entry = self._format(item)
+            if self.show_secrets and self.name:
+                secrets = self._list_secrets()
+                # Register secret values with Ansible's redaction pool so they
+                # never appear in verbose (`-vvv`) or callback logs, even though
+                # they are returned in the module result for programmatic use.
+                for secret in secrets:
+                    value = secret.get('value')
+                    if value:
+                        self.module.no_log_values.add(value)
+                entry['secrets'] = secrets
+            formatted.append(entry)
+
+        self.results['container_apps'] = formatted
+        return self.results
+
+    def _get(self):
+        try:
+            return [self.containerapps_client.container_apps.get(
+                resource_group_name=self.resource_group,
+                container_app_name=self.name,
+            )]
+        except ResourceNotFoundError:
+            return []
+        except Exception as exc:
+            self.fail("Error retrieving container app {0}: {1}".format(self.name, str(exc)))
+
+    def _list_by_rg(self):
+        try:
+            return list(self.containerapps_client.container_apps.list_by_resource_group(
+                resource_group_name=self.resource_group,
+            ))
+        except Exception as exc:
+            self.fail("Error listing container apps in {0}: {1}".format(self.resource_group, str(exc)))
+
+    def _list_by_sub(self):
+        try:
+            return list(self.containerapps_client.container_apps.list_by_subscription())
+        except Exception as exc:
+            self.fail("Error listing container apps: {0}".format(str(exc)))
+
+    def _list_secrets(self):
+        try:
+            response = self.containerapps_client.container_apps.list_secrets(
+                resource_group_name=self.resource_group,
+                container_app_name=self.name,
+            )
+        except Exception as exc:
+            self.fail("Error listing secrets for container app {0}: {1}".format(self.name, str(exc)))
+
+        raw = _normalize(response)
+        return raw.get('value', []) if raw else []
+
+    def _format(self, item):
+        return _normalize(item)
+
+    def _match_tags(self, item):
+        if not self.tags:
+            return True
+        tags = getattr(item, 'tags', None) or {}
+        return self.has_tags(tags, self.tags)
+
+
+def main():
+    AzureRMContainerAppInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_containerappenvironment.py
+++ b/plugins/modules/azure_rm_containerappenvironment.py
@@ -1,0 +1,570 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_containerappenvironment
+version_added: "4.0.0"
+short_description: Manage Azure Container Apps Managed Environment
+description:
+    - Create, update and delete an Azure Container Apps Managed Environment.
+    - Managed environments are the shared runtime that hosts one or more Container Apps.
+
+options:
+    resource_group:
+        description:
+            - The name of the resource group.
+        required: true
+        type: str
+    name:
+        description:
+            - Name of the managed environment.
+        required: true
+        type: str
+    location:
+        description:
+            - Resource location. If not set, location from the resource group will be used.
+        type: str
+    zone_redundant:
+        description:
+            - Whether the managed environment is zone-redundant.
+            - Requires I(vnet_configuration.infrastructure_subnet_id) to be set.
+        type: bool
+    vnet_configuration:
+        description:
+            - VNet configuration for the environment.
+        type: dict
+        suboptions:
+            internal:
+                description:
+                    - Whether the environment only has an internal load balancer.
+                    - Requires I(infrastructure_subnet_id) to be set.
+                type: bool
+            infrastructure_subnet_id:
+                description:
+                    - Resource ID of a subnet for infrastructure components.
+                type: str
+            docker_bridge_cidr:
+                description:
+                    - CIDR notation IP range assigned to the Docker bridge network.
+                type: str
+            platform_reserved_cidr:
+                description:
+                    - IP range in CIDR notation reserved for environment infrastructure IP addresses.
+                type: str
+            platform_reserved_dns_ip:
+                description:
+                    - IP address from the range defined by I(platform_reserved_cidr) reserved for the internal DNS server.
+                type: str
+    app_logs_configuration:
+        description:
+            - Cluster configuration which enables the log daemon to export app logs.
+        type: dict
+        suboptions:
+            destination:
+                description:
+                    - Logs destination.
+                type: str
+                choices:
+                    - log-analytics
+                    - azure-monitor
+                    - none
+            log_analytics_configuration:
+                description:
+                    - Log Analytics configuration. Required when I(destination=log-analytics).
+                type: dict
+                suboptions:
+                    customer_id:
+                        description:
+                            - Log Analytics workspace customer ID.
+                        type: str
+                    shared_key:
+                        description:
+                            - Log Analytics workspace shared key.
+                        type: str
+    workload_profiles:
+        description:
+            - Workload profiles configured for the managed environment.
+            - When omitted, the environment is created in the Consumption-only workload profile.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description:
+                    - Workload profile display name.
+                required: true
+                type: str
+            workload_profile_type:
+                description:
+                    - Workload profile type. Common values are C(Consumption), C(D4), C(D8), C(D16), C(D32), C(E4), C(E8), C(E16), C(E32).
+                required: true
+                type: str
+            minimum_count:
+                description:
+                    - Minimum capacity for dedicated workload profiles.
+                type: int
+            maximum_count:
+                description:
+                    - Maximum capacity for dedicated workload profiles.
+                type: int
+    dapr_ai_connection_string:
+        description:
+            - Application Insights connection string used by Dapr to export Service to Service communication telemetry.
+        type: str
+    infrastructure_resource_group:
+        description:
+            - Name of the platform-managed resource group created for the managed environment infrastructure.
+            - Read-only unless I(workload_profiles) is set and I(vnet_configuration.infrastructure_subnet_id) is provided.
+        type: str
+    public_network_access:
+        description:
+            - Whether the environment accepts traffic from the public network.
+        type: str
+        choices:
+            - Enabled
+            - Disabled
+    peer_authentication_mtls_enabled:
+        description:
+            - Whether mutual TLS authentication is enabled between apps in the environment.
+        type: bool
+    peer_traffic_encryption_enabled:
+        description:
+            - Whether peer-to-peer traffic encryption is enabled in the environment.
+        type: bool
+    state:
+        description:
+            - Assert the state of the managed environment.
+            - Use C(present) to create or update, C(absent) to delete.
+        default: present
+        type: str
+        choices:
+            - present
+            - absent
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+    - azure.azcollection.azure_tags
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Create a managed environment (Consumption profile, no VNet)
+  azure.azcollection.azure_rm_containerappenvironment:
+    resource_group: myResourceGroup
+    name: myenv
+    location: eastus
+    app_logs_configuration:
+      destination: log-analytics
+      log_analytics_configuration:
+        customer_id: "{{ workspace_customer_id }}"
+        shared_key: "{{ workspace_shared_key }}"
+
+- name: Create a VNet-integrated environment with dedicated workload profile
+  azure.azcollection.azure_rm_containerappenvironment:
+    resource_group: myResourceGroup
+    name: myenv-vnet
+    location: eastus
+    zone_redundant: true
+    vnet_configuration:
+      internal: true
+      infrastructure_subnet_id: "/subscriptions/xxxx/resourceGroups/net/providers/Microsoft.Network/virtualNetworks/vnet/subnets/aca-infra"
+    workload_profiles:
+      - name: Consumption
+        workload_profile_type: Consumption
+      - name: dedicated-d4
+        workload_profile_type: D4
+        minimum_count: 1
+        maximum_count: 3
+    peer_authentication_mtls_enabled: true
+    tags:
+      environment: prod
+
+- name: Delete the managed environment
+  azure.azcollection.azure_rm_containerappenvironment:
+    resource_group: myResourceGroup
+    name: myenv
+    state: absent
+'''
+
+RETURN = '''
+state:
+    description:
+        - Current state of the managed environment.
+    returned: always
+    type: complex
+    contains:
+        id:
+            description:
+                - Fully qualified resource ID of the managed environment.
+            type: str
+            returned: always
+            sample: "/subscriptions/xxxx/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/myenv"
+        name:
+            description:
+                - Name of the managed environment.
+            type: str
+            returned: always
+            sample: myenv
+        type:
+            description:
+                - Resource type.
+            type: str
+            returned: always
+            sample: Microsoft.App/managedEnvironments
+        location:
+            description:
+                - Resource location.
+            type: str
+            returned: always
+            sample: eastus
+        tags:
+            description:
+                - Resource tags.
+            type: dict
+            returned: always
+            sample: { environment: prod }
+        provisioning_state:
+            description:
+                - Provisioning state of the environment.
+            type: str
+            returned: always
+            sample: Succeeded
+        default_domain:
+            description:
+                - Default domain name for the environment.
+            type: str
+            returned: always
+            sample: myenv.polite-1234abcd.eastus.azurecontainerapps.io
+        static_ip:
+            description:
+                - Static IP of the environment.
+            type: str
+            returned: always
+            sample: 20.10.20.30
+        zone_redundant:
+            description:
+                - Whether the environment is zone redundant.
+            type: bool
+            returned: always
+            sample: false
+        vnet_configuration:
+            description:
+                - VNet configuration used by the environment.
+            type: dict
+            returned: always
+        workload_profiles:
+            description:
+                - Workload profiles configured on the environment.
+            type: list
+            returned: always
+        app_logs_configuration:
+            description:
+                - App logs configuration for the environment.
+            type: dict
+            returned: always
+        public_network_access:
+            description:
+                - Whether the environment accepts public network traffic.
+            type: str
+            returned: always
+            sample: Enabled
+'''
+
+try:
+    from azure.core.polling import LROPoller
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
+    from azure.mgmt.appcontainers.models import (
+        ManagedEnvironment, VnetConfiguration, AppLogsConfiguration,
+        LogAnalyticsConfiguration, WorkloadProfile,
+        ManagedEnvironmentPropertiesPeerAuthentication, Mtls,
+        ManagedEnvironmentPropertiesPeerTrafficConfiguration,
+        ManagedEnvironmentPropertiesPeerTrafficConfigurationEncryption,
+    )
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+
+
+def _normalize(obj):
+    """
+    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    return as_attribute_dict(obj, exclude_readonly=False)
+
+
+def _build_env_model(params):
+    """Construct a ``ManagedEnvironment`` from a snake_case dict.
+
+    ``azure-mgmt-appcontainers`` 5.0.0 uses hybrid/typed models — passing a
+    flat dict directly leaves resource-specific fields at the top level
+    instead of ARM's required ``properties`` envelope. Build the model tree
+    explicitly (mirroring the ``azure_rm_keyvault`` migration pattern) so the
+    wire payload is nested under ``properties`` with correct camelCase keys.
+    """
+    vnet = params.get('vnet_configuration')
+    if vnet is not None:
+        vnet = VnetConfiguration(**{k: v for k, v in vnet.items() if v is not None})
+
+    logs = params.get('app_logs_configuration')
+    if logs is not None:
+        la = logs.get('log_analytics_configuration')
+        if la is not None:
+            la = LogAnalyticsConfiguration(**{k: v for k, v in la.items() if v is not None})
+        logs = AppLogsConfiguration(destination=logs.get('destination'), log_analytics_configuration=la)
+
+    profiles = params.get('workload_profiles')
+    if profiles is not None:
+        profiles = [WorkloadProfile(**{k: v for k, v in wp.items() if v is not None}) for wp in profiles]
+
+    peer_auth = params.get('peer_authentication')
+    if peer_auth is not None:
+        mtls_cfg = peer_auth.get('mtls')
+        mtls_cfg = Mtls(**mtls_cfg) if mtls_cfg else None
+        peer_auth = ManagedEnvironmentPropertiesPeerAuthentication(mtls=mtls_cfg)
+
+    peer_traffic = params.get('peer_traffic_configuration')
+    if peer_traffic is not None:
+        enc = peer_traffic.get('encryption')
+        enc = ManagedEnvironmentPropertiesPeerTrafficConfigurationEncryption(**enc) if enc else None
+        peer_traffic = ManagedEnvironmentPropertiesPeerTrafficConfiguration(encryption=enc)
+
+    return ManagedEnvironment(
+        location=params.get('location'),
+        tags=params.get('tags'),
+        zone_redundant=params.get('zone_redundant'),
+        vnet_configuration=vnet,
+        app_logs_configuration=logs,
+        workload_profiles=profiles,
+        dapr_ai_connection_string=params.get('dapr_ai_connection_string'),
+        infrastructure_resource_group=params.get('infrastructure_resource_group'),
+        public_network_access=params.get('public_network_access'),
+        peer_authentication=peer_auth,
+        peer_traffic_configuration=peer_traffic,
+    )
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+vnet_configuration_spec = dict(
+    internal=dict(type='bool'),
+    infrastructure_subnet_id=dict(type='str'),
+    docker_bridge_cidr=dict(type='str'),
+    platform_reserved_cidr=dict(type='str'),
+    platform_reserved_dns_ip=dict(type='str'),
+)
+
+
+log_analytics_configuration_spec = dict(
+    customer_id=dict(type='str'),
+    shared_key=dict(type='str', no_log=True),
+)
+
+
+app_logs_configuration_spec = dict(
+    destination=dict(type='str', choices=['log-analytics', 'azure-monitor', 'none']),
+    log_analytics_configuration=dict(type='dict', options=log_analytics_configuration_spec),
+)
+
+
+workload_profile_spec = dict(
+    name=dict(type='str', required=True),
+    workload_profile_type=dict(type='str', required=True),
+    minimum_count=dict(type='int'),
+    maximum_count=dict(type='int'),
+)
+
+
+class AzureRMContainerAppEnvironment(AzureRMModuleBaseExt):
+    """Manage Container Apps Managed Environment resources."""
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            name=dict(type='str', required=True),
+            location=dict(type='str'),
+            zone_redundant=dict(type='bool'),
+            vnet_configuration=dict(type='dict', options=vnet_configuration_spec),
+            app_logs_configuration=dict(type='dict', options=app_logs_configuration_spec),
+            workload_profiles=dict(type='list', elements='dict', options=workload_profile_spec),
+            dapr_ai_connection_string=dict(type='str', no_log=True),
+            infrastructure_resource_group=dict(type='str'),
+            public_network_access=dict(type='str', choices=['Enabled', 'Disabled']),
+            peer_authentication_mtls_enabled=dict(type='bool'),
+            peer_traffic_encryption_enabled=dict(type='bool'),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.location = None
+        self.tags = None
+        self.state = None
+
+        self.parameters = dict()
+        self.update_parameters = dict()
+
+        self.results = dict(changed=False)
+        self.to_do = Actions.NoAction
+
+        super(AzureRMContainerAppEnvironment, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=True,
+        )
+
+    def exec_module(self, **kwargs):
+        """Main module execution."""
+
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
+            elif kwargs[key] is not None:
+                self._assign_parameter(key, kwargs[key])
+
+        resource_group = self.get_resource_group(self.resource_group)
+        if self.location is None:
+            self.location = resource_group.location
+        self.parameters['location'] = self.location
+
+        old_response = self.get_resource()
+
+        changed = False
+        if old_response is None:
+            if self.state == 'present':
+                self.to_do = Actions.Create
+                changed = True
+        else:
+            if self.state == 'absent':
+                self.to_do = Actions.Delete
+                changed = True
+            else:
+                update_tags, self.update_parameters['tags'] = self.update_tags(old_response.get('tags'))
+                if update_tags:
+                    changed = True
+                    self.to_do = Actions.Update
+
+                for item in ('zone_redundant', 'public_network_access', 'infrastructure_resource_group',
+                             'vnet_configuration', 'app_logs_configuration', 'workload_profiles',
+                             'peer_authentication', 'peer_traffic_configuration'):
+                    if not self.default_compare({}, self.parameters.get(item), old_response.get(item), '', dict(compare=[])):
+                        changed = True
+                        self.to_do = Actions.Update
+
+        if self.to_do in (Actions.Create, Actions.Update):
+            if not self.check_mode:
+                self.create_update_resource()
+                self.results['state'] = self.get_resource()
+            else:
+                self.results['state'] = old_response or self.parameters
+        elif self.to_do == Actions.Delete:
+            if not self.check_mode:
+                self.delete_resource()
+            self.results['state'] = dict()
+        else:
+            self.results['state'] = old_response or dict()
+
+        self.results['changed'] = changed
+        return self.results
+
+    def _assign_parameter(self, key, value):
+        if key == 'peer_authentication_mtls_enabled':
+            self.parameters.setdefault('peer_authentication', dict())['mtls'] = dict(enabled=value)
+            self.update_parameters.setdefault('peer_authentication', dict())['mtls'] = dict(enabled=value)
+        elif key == 'peer_traffic_encryption_enabled':
+            self.parameters.setdefault('peer_traffic_configuration', dict())['encryption'] = dict(enabled=value)
+            self.update_parameters.setdefault('peer_traffic_configuration', dict())['encryption'] = dict(enabled=value)
+        else:
+            self.parameters[key] = value
+            # A subset of properties are updatable via PATCH
+            if key in ('workload_profiles', 'app_logs_configuration', 'vnet_configuration',
+                       'public_network_access', 'dapr_ai_connection_string',
+                       'peer_authentication', 'peer_traffic_configuration'):
+                self.update_parameters[key] = value
+
+    def create_update_resource(self):
+        self.log("Creating / Updating managed environment {0}".format(self.name))
+        try:
+            if self.to_do == Actions.Create:
+                self.parameters['tags'] = self.tags
+                envelope = _build_env_model(self.parameters)
+                response = self.containerapps_client.managed_environments.begin_create_or_update(
+                    resource_group_name=self.resource_group,
+                    environment_name=self.name,
+                    environment_envelope=envelope,
+                )
+            else:
+                envelope = _build_env_model(self.update_parameters)
+                response = self.containerapps_client.managed_environments.begin_update(
+                    resource_group_name=self.resource_group,
+                    environment_name=self.name,
+                    environment_envelope=envelope,
+                )
+            if isinstance(response, LROPoller):
+                response = self.get_poller_result(response)
+        except Exception as exc:
+            self.fail("Error creating/updating managed environment {0}: {1}".format(self.name, str(exc)))
+
+        return self.format_item(response)
+
+    def delete_resource(self):
+        self.log("Deleting managed environment {0}".format(self.name))
+        try:
+            response = self.containerapps_client.managed_environments.begin_delete(
+                resource_group_name=self.resource_group,
+                environment_name=self.name,
+            )
+            if isinstance(response, LROPoller):
+                self.get_poller_result(response)
+        except Exception as exc:
+            self.fail("Error deleting managed environment {0}: {1}".format(self.name, str(exc)))
+        return True
+
+    def get_resource(self):
+        self.log("Checking if managed environment {0} exists".format(self.name))
+        try:
+            response = self.containerapps_client.managed_environments.get(
+                resource_group_name=self.resource_group,
+                environment_name=self.name,
+            )
+        except ResourceNotFoundError:
+            return None
+        except Exception as exc:
+            self.fail("Error retrieving managed environment {0}: {1}".format(self.name, str(exc)))
+        return self.format_item(response)
+
+    def format_item(self, item):
+        if item is None:
+            return None
+        normalized = _normalize(item)
+        if normalized.get('id'):
+            parsed = self.parse_resource_to_dict(normalized['id'])
+            normalized['resource_group'] = parsed.get('resource_group')
+        else:
+            normalized['resource_group'] = self.resource_group
+        return normalized
+
+
+def main():
+    AzureRMContainerAppEnvironment()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_containerappenvironment.py
+++ b/plugins/modules/azure_rm_containerappenvironment.py
@@ -294,18 +294,22 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
+import copy
+
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 
-def _normalize(obj):
+def _strip_write_only(parameters):
+    """Remove fields that Azure never returns on read (e.g. Log Analytics
+    ``shared_key``) so idempotence compare against the fetched state does not
+    always report a diff.
     """
-    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model.
-    """
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        return obj
-    return as_attribute_dict(obj, exclude_readonly=False)
+    sanitized = copy.deepcopy(parameters)
+    logs = sanitized.get('app_logs_configuration') or {}
+    la = logs.get('log_analytics_configuration') or {}
+    if 'shared_key' in la:
+        la.pop('shared_key', None)
+    return sanitized
 
 
 def _build_env_model(params):
@@ -461,10 +465,11 @@ class AzureRMContainerAppEnvironment(AzureRMModuleBaseExt):
                     changed = True
                     self.to_do = Actions.Update
 
+                sanitized = _strip_write_only(self.parameters)
                 for item in ('zone_redundant', 'public_network_access', 'infrastructure_resource_group',
                              'vnet_configuration', 'app_logs_configuration', 'workload_profiles',
                              'peer_authentication', 'peer_traffic_configuration'):
-                    if not self.default_compare({}, self.parameters.get(item), old_response.get(item), '', dict(compare=[])):
+                    if not self.default_compare({}, sanitized.get(item), old_response.get(item), '', dict(compare=[])):
                         changed = True
                         self.to_do = Actions.Update
 
@@ -553,7 +558,7 @@ class AzureRMContainerAppEnvironment(AzureRMModuleBaseExt):
     def format_item(self, item):
         if item is None:
             return None
-        normalized = _normalize(item)
+        normalized = as_attribute_dict(item, exclude_readonly=False)
         if normalized.get('id'):
             parsed = self.parse_resource_to_dict(normalized['id'])
             normalized['resource_group'] = parsed.get('resource_group')

--- a/plugins/modules/azure_rm_containerappenvironment_info.py
+++ b/plugins/modules/azure_rm_containerappenvironment_info.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2026 Zun Yang (@zunyangc)
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_containerappenvironment_info
+version_added: "4.0.0"
+short_description: Get facts about Azure Container Apps Managed Environments
+description:
+    - Get facts about one or many Azure Container Apps Managed Environments.
+
+options:
+    resource_group:
+        description:
+            - Name of the resource group.
+            - Required when I(name) is used.
+        type: str
+    name:
+        description:
+            - Name of the managed environment. When omitted, all environments in scope are returned.
+        type: str
+    tags:
+        description:
+            - Limit results by providing a list of tags formatted as C(key) or C(key:value).
+        type: list
+        elements: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Get a single managed environment
+  azure.azcollection.azure_rm_containerappenvironment_info:
+    resource_group: myResourceGroup
+    name: myenv
+
+- name: List all environments in a resource group
+  azure.azcollection.azure_rm_containerappenvironment_info:
+    resource_group: myResourceGroup
+
+- name: List all environments in the subscription
+  azure.azcollection.azure_rm_containerappenvironment_info:
+'''
+
+RETURN = '''
+managed_environments:
+    description:
+        - List of managed environments matching the filter.
+    returned: always
+    type: list
+    elements: dict
+'''
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.serialization import as_attribute_dict
+except ImportError:
+    pass
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+
+
+def _normalize(obj):
+    """
+    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model
+    via the Azure SDK's official ``as_attribute_dict`` backcompat helper.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    return as_attribute_dict(obj, exclude_readonly=False)
+
+
+class AzureRMContainerAppEnvironmentInfo(AzureRMModuleBase):
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str'),
+            name=dict(type='str'),
+            tags=dict(type='list', elements='str'),
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.tags = None
+
+        self.results = dict(changed=False, managed_environments=[])
+
+        super(AzureRMContainerAppEnvironmentInfo, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in self.module_arg_spec:
+            setattr(self, key, kwargs[key])
+
+        if self.name and not self.resource_group:
+            self.fail("resource_group is required when name is specified")
+
+        if self.name:
+            items = self._get()
+        elif self.resource_group:
+            items = self._list_by_rg()
+        else:
+            items = self._list_by_sub()
+
+        self.results['managed_environments'] = [self._format(i) for i in items if self._match_tags(i)]
+        return self.results
+
+    def _get(self):
+        try:
+            return [self.containerapps_client.managed_environments.get(
+                resource_group_name=self.resource_group,
+                environment_name=self.name,
+            )]
+        except ResourceNotFoundError:
+            return []
+        except Exception as exc:
+            self.fail("Error retrieving managed environment {0}: {1}".format(self.name, str(exc)))
+
+    def _list_by_rg(self):
+        try:
+            return list(self.containerapps_client.managed_environments.list_by_resource_group(
+                resource_group_name=self.resource_group,
+            ))
+        except Exception as exc:
+            self.fail("Error listing managed environments in {0}: {1}".format(self.resource_group, str(exc)))
+
+    def _list_by_sub(self):
+        try:
+            return list(self.containerapps_client.managed_environments.list_by_subscription())
+        except Exception as exc:
+            self.fail("Error listing managed environments: {0}".format(str(exc)))
+
+    def _format(self, item):
+        return _normalize(item)
+
+    def _match_tags(self, item):
+        if not self.tags:
+            return True
+        tags = getattr(item, 'tags', None) or {}
+        return self.has_tags(tags, self.tags)
+
+
+def main():
+    AzureRMContainerAppEnvironmentInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_containerappenvironment_info.py
+++ b/plugins/modules/azure_rm_containerappenvironment_info.py
@@ -71,18 +71,6 @@ except ImportError:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
 
 
-def _normalize(obj):
-    """
-    Return a snake_case flat dict for an ``azure-mgmt-appcontainers`` model
-    via the Azure SDK's official ``as_attribute_dict`` backcompat helper.
-    """
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        return obj
-    return as_attribute_dict(obj, exclude_readonly=False)
-
-
 class AzureRMContainerAppEnvironmentInfo(AzureRMModuleBase):
     def __init__(self):
         self.module_arg_spec = dict(
@@ -118,7 +106,10 @@ class AzureRMContainerAppEnvironmentInfo(AzureRMModuleBase):
         else:
             items = self._list_by_sub()
 
-        self.results['managed_environments'] = [self._format(i) for i in items if self._match_tags(i)]
+        self.results['managed_environments'] = [
+            self._format(i) for i in items
+            if not self.tags or self.has_tags(getattr(i, 'tags', None) or {}, self.tags)
+        ]
         return self.results
 
     def _get(self):
@@ -147,13 +138,7 @@ class AzureRMContainerAppEnvironmentInfo(AzureRMModuleBase):
             self.fail("Error listing managed environments: {0}".format(str(exc)))
 
     def _format(self, item):
-        return _normalize(item)
-
-    def _match_tags(self, item):
-        if not self.tags:
-            return True
-        tags = getattr(item, 'tags', None) or {}
-        return self.has_tags(tags, self.tags)
+        return as_attribute_dict(item, exclude_readonly=False) if item else None
 
 
 def main():

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -53,6 +53,7 @@ parameters:
       - "azure_rm_cdnprofile"
       - "azure_rm_cognitiveservices"
       - "azure_rm_cognitiveservicesaccount"
+      - "azure_rm_containerapp"
       - "azure_rm_containerinstance"
       - "azure_rm_containerregistry"
       - "azure_rm_containerregistryscopemap"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ azure-mgmt-batch==17.3.0
 azure-mgmt-cdn==13.1.1
 azure-mgmt-cognitiveservices==13.7.0
 azure-mgmt-compute==33.0.0
+azure-mgmt-appcontainers==5.0.0
 azure-mgmt-containerinstance==10.1.0
 azure-mgmt-containerregistry==10.3.0
 azure-mgmt-containerservice==32.1.0

--- a/tests/integration/targets/azure_rm_containerapp/aliases
+++ b/tests/integration/targets/azure_rm_containerapp/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+destructive
+shippable/azure/group14

--- a/tests/integration/targets/azure_rm_containerapp/meta/main.yml
+++ b/tests/integration/targets/azure_rm_containerapp/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_containerapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerapp/tasks/main.yml
@@ -1,23 +1,35 @@
-- name: Create a new resource group for container app test
+- name: Create test resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}-containerapp"
     location: eastus2
 
-- name: For container app test
+- name: For container app coverage
   block:
-    - name: Prepare random suffix for names
+    - name: Prepare random suffix
       ansible.builtin.set_fact:
         rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       run_once: true
 
-    - name: Create Log Analytics workspace for the environment
+    - name: Set derived facts
+      ansible.builtin.set_fact:
+        env_name: "env-aca-{{ rpfx }}"
+        app_name: "app-aca-{{ rpfx }}"
+        umi_name: "umi-aca-{{ rpfx }}"
+        umi_id: "/subscriptions/{{ azure_subscription_id }}/resourcegroups/{{ resource_group }}-containerapp/providers/Microsoft.ManagedIdentity/userAssignedIdentities/umi-aca-{{ rpfx }}"
+
+    - name: Create Log Analytics workspace
       azure.azcollection.azure_rm_loganalyticsworkspace:
         resource_group: "{{ resource_group }}-containerapp"
         name: "law-aca-{{ rpfx }}"
         location: eastus2
-        sku: PerGB2018
+        sku: per_gb2018
         retention_in_days: 30
       register: law
+
+    - name: Assert workspace created
+      ansible.builtin.assert:
+        that:
+          - law.customer_id is defined
 
     - name: Fetch workspace shared keys
       azure.azcollection.azure_rm_loganalyticsworkspace_info:
@@ -26,39 +38,75 @@
         show_shared_keys: true
       register: law_keys
 
-    - name: Create Container Apps managed environment (check mode)
+    - name: Assert shared keys present
+      ansible.builtin.assert:
+        that:
+          - law_keys.workspaces[0].shared_keys.primary_shared_key is defined
+
+    - name: Create user-assigned managed identity
+      azure.azcollection.azure_rm_resource:
+        resource_group: "{{ resource_group }}-containerapp"
+        provider: ManagedIdentity
+        resource_type: userAssignedIdentities
+        resource_name: "{{ umi_name }}"
+        api_version: "2023-01-31"
+        body:
+          location: eastus2
+        state: present
+      register: umi
+
+    - name: Assert UMI created
+      ansible.builtin.assert:
+        that:
+          - umi is not failed
+
+    - name: Environment create (check mode)
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
         location: eastus2
         app_logs_configuration:
           destination: log-analytics
           log_analytics_configuration:
-            customer_id: "{{ law.state.customer_id }}"
+            customer_id: "{{ law.customer_id }}"
             shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        workload_profiles:
+          - name: Consumption
+            workload_profile_type: Consumption
+        public_network_access: Enabled
+        peer_authentication_mtls_enabled: false
+        peer_traffic_encryption_enabled: false
         tags:
           role: integration
+          feature: full
       check_mode: true
       register: env_check
 
-    - name: Assert environment check mode reported change
+    - name: Assert environment check mode changed
       ansible.builtin.assert:
         that:
           - env_check is changed
-          - env_check.state == {} or env_check.state is defined
+          - env_check.state.id is not defined
 
-    - name: Create Container Apps managed environment
+    - name: Environment create
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
         location: eastus2
         app_logs_configuration:
           destination: log-analytics
           log_analytics_configuration:
-            customer_id: "{{ law.state.customer_id }}"
+            customer_id: "{{ law.customer_id }}"
             shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        workload_profiles:
+          - name: Consumption
+            workload_profile_type: Consumption
+        public_network_access: Enabled
+        peer_authentication_mtls_enabled: false
+        peer_traffic_encryption_enabled: false
         tags:
           role: integration
+          feature: full
       register: env_create
 
     - name: Assert environment created
@@ -66,21 +114,37 @@
         that:
           - env_create is changed
           - env_create.state.id is defined
-          - env_create.state.name == "env-aca-" ~ rpfx
+          - env_create.state.name == env_name
           - env_create.state.provisioning_state == "Succeeded"
+          - env_create.state.location | lower | replace(" ", "") == "eastus2"
+          - env_create.state.app_logs_configuration.destination == "log-analytics"
+          - env_create.state.app_logs_configuration.log_analytics_configuration.customer_id == law.customer_id
+          - env_create.state.public_network_access == "Enabled"
+          - env_create.state.peer_authentication.mtls.enabled == false
+          - env_create.state.peer_traffic_configuration.encryption.enabled == false
+          - env_create.state.workload_profiles | length >= 1
+          - env_create.state.tags.role == "integration"
+          - env_create.state.tags.feature == "full"
 
-    - name: Create environment again (idempotence)
+    - name: Environment create (idempotence)
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
         location: eastus2
         app_logs_configuration:
           destination: log-analytics
           log_analytics_configuration:
-            customer_id: "{{ law.state.customer_id }}"
+            customer_id: "{{ law.customer_id }}"
             shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        workload_profiles:
+          - name: Consumption
+            workload_profile_type: Consumption
+        public_network_access: Enabled
+        peer_authentication_mtls_enabled: false
+        peer_traffic_encryption_enabled: false
         tags:
           role: integration
+          feature: full
       register: env_idem
 
     - name: Assert environment idempotent
@@ -88,343 +152,966 @@
         that:
           - env_idem is not changed
 
-    - name: Update environment tags
+    - name: Environment update peer auth and tags
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
         location: eastus2
         app_logs_configuration:
           destination: log-analytics
           log_analytics_configuration:
-            customer_id: "{{ law.state.customer_id }}"
+            customer_id: "{{ law.customer_id }}"
             shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        workload_profiles:
+          - name: Consumption
+            workload_profile_type: Consumption
+        public_network_access: Enabled
+        peer_authentication_mtls_enabled: true
+        peer_traffic_encryption_enabled: true
         tags:
           role: integration
+          feature: full
           updated: "true"
       register: env_update
 
-    - name: Assert environment tag update reported change
+    - name: Assert environment update changed
       ansible.builtin.assert:
         that:
           - env_update is changed
+          - env_update.state.peer_authentication.mtls.enabled == true
+          - env_update.state.peer_traffic_configuration.encryption.enabled == true
           - env_update.state.tags.updated == "true"
 
-    - name: Fetch environment via info module (by name)
+    - name: Environment update (idempotence)
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "{{ env_name }}"
+        location: eastus2
+        app_logs_configuration:
+          destination: log-analytics
+          log_analytics_configuration:
+            customer_id: "{{ law.customer_id }}"
+            shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        workload_profiles:
+          - name: Consumption
+            workload_profile_type: Consumption
+        public_network_access: Enabled
+        peer_authentication_mtls_enabled: true
+        peer_traffic_encryption_enabled: true
+        tags:
+          role: integration
+          feature: full
+          updated: "true"
+      register: env_update_idem
+
+    - name: Assert environment update idempotent
+      ansible.builtin.assert:
+        that:
+          - env_update_idem is not changed
+
+    - name: Environment info by name
       azure.azcollection.azure_rm_containerappenvironment_info:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
       register: env_info
 
-    - name: Assert env info returns exactly one entry
+    - name: Assert environment info single entry
       ansible.builtin.assert:
         that:
           - env_info.managed_environments | length == 1
-          - env_info.managed_environments[0].name == "env-aca-" ~ rpfx
+          - env_info.managed_environments[0].name == env_name
           - env_info.managed_environments[0].provisioning_state == "Succeeded"
+          - env_info.managed_environments[0].peer_authentication.mtls.enabled == true
 
-    - name: List all environments in the resource group
+    - name: Environment info list by resource group
       azure.azcollection.azure_rm_containerappenvironment_info:
         resource_group: "{{ resource_group }}-containerapp"
-      register: env_list
+      register: env_list_rg
 
-    - name: Assert env list contains the test environment
+    - name: Assert environment list by RG contains env
       ansible.builtin.assert:
         that:
-          - env_list.managed_environments | length >= 1
-          - "'env-aca-' ~ rpfx in (env_list.managed_environments | map(attribute='name') | list)"
+          - env_list_rg.managed_environments | length >= 1
+          - env_name in (env_list_rg.managed_environments | map(attribute='name') | list)
 
-    - name: Create container app (check mode)
+    - name: Environment info tag filter match
+      azure.azcollection.azure_rm_containerappenvironment_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        tags:
+          - "role:integration"
+      register: env_tag_match
+
+    - name: Assert environment tag filter match
+      ansible.builtin.assert:
+        that:
+          - env_tag_match.managed_environments | length >= 1
+          - env_name in (env_tag_match.managed_environments | map(attribute='name') | list)
+
+    - name: Environment info tag filter miss
+      azure.azcollection.azure_rm_containerappenvironment_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        tags:
+          - "role:nonexistent-tag-value"
+      register: env_tag_miss
+
+    - name: Assert environment tag filter empty
+      ansible.builtin.assert:
+        that:
+          - env_tag_miss.managed_environments | length == 0
+
+    - name: Environment info by name not found
+      azure.azcollection.azure_rm_containerappenvironment_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "does-not-exist-{{ rpfx }}"
+      register: env_missing
+
+    - name: Assert environment info empty on missing
+      ansible.builtin.assert:
+        that:
+          - env_missing.managed_environments | length == 0
+
+    - name: Container app create (check mode)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         location: eastus2
         environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: SystemAssigned
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
         ingress:
           external: true
           target_port: 80
           transport: auto
+          allow_insecure: false
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: true
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v1
+        termination_grace_period_seconds: 30
         containers:
           - name: hello
             image: mcr.microsoft.com/k8se/quickstart:latest
             resources:
+              cpu: 0.5
+              memory: 1Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
               cpu: 0.25
               memory: 0.5Gi
         scale:
-          min_replicas: 0
-          max_replicas: 2
+          min_replicas: 1
+          max_replicas: 3
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
         tags:
           role: integration
       check_mode: true
       register: app_check
 
-    - name: Assert container app check mode reported change
+    - name: Assert app check mode changed
       ansible.builtin.assert:
         that:
           - app_check is changed
+          - app_check.state.id is not defined
 
-    - name: Create container app
+    - name: Container app create
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         location: eastus2
         environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: SystemAssigned
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
         ingress:
           external: true
           target_port: 80
           transport: auto
+          allow_insecure: false
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: true
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v1
+        termination_grace_period_seconds: 30
         containers:
           - name: hello
             image: mcr.microsoft.com/k8se/quickstart:latest
             resources:
+              cpu: 0.5
+              memory: 1Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
               cpu: 0.25
               memory: 0.5Gi
         scale:
-          min_replicas: 0
-          max_replicas: 2
+          min_replicas: 1
+          max_replicas: 3
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
         tags:
           role: integration
       register: app_create
 
-    - name: Assert container app created
+    - name: Assert app created with full payload
       ansible.builtin.assert:
         that:
           - app_create is changed
           - app_create.state.id is defined
-          - app_create.state.name == "app-aca-" ~ rpfx
+          - app_create.state.name == app_name
           - app_create.state.provisioning_state == "Succeeded"
+          - app_create.state.identity.type == "SystemAssigned"
+          - app_create.state.identity.principal_id is defined
+          - app_create.state.workload_profile_name == "Consumption"
+          - app_create.state.configuration.active_revisions_mode == "Multiple"
+          - app_create.state.configuration.max_inactive_revisions == 5
+          - app_create.state.configuration.secrets | length == 2
+          - app_create.state.configuration.ingress.external == true
+          - app_create.state.configuration.ingress.target_port == 80
+          - app_create.state.configuration.ingress.transport | lower == "auto"
+          - app_create.state.configuration.ingress.ip_security_restrictions | length == 1
+          - app_create.state.configuration.ingress.cors_policy.allowed_origins | length == 1
+          - app_create.state.configuration.dapr.enabled == true
+          - app_create.state.configuration.dapr.app_id == "hello-dapr"
+          - app_create.state.template.revision_suffix == "v1"
+          - app_create.state.template.termination_grace_period_seconds == 30
+          - app_create.state.template.containers | length == 1
+          - app_create.state.template.containers[0].image == "mcr.microsoft.com/k8se/quickstart:latest"
+          - app_create.state.template.containers[0].env | length == 2
+          - app_create.state.template.containers[0].probes | length >= 1
+          - app_create.state.template.containers[0].volume_mounts | length == 1
+          - app_create.state.template.init_containers | length == 1
+          - app_create.state.template.scale.min_replicas == 1
+          - app_create.state.template.scale.max_replicas == 3
+          - app_create.state.template.scale.rules | length == 1
+          - app_create.state.template.volumes | length == 1
 
-    - name: Create container app again (idempotence)
+    - name: Container app create (idempotence)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         location: eastus2
         environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: SystemAssigned
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
         ingress:
           external: true
           target_port: 80
           transport: auto
+          allow_insecure: false
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: true
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v1
+        termination_grace_period_seconds: 30
         containers:
           - name: hello
             image: mcr.microsoft.com/k8se/quickstart:latest
             resources:
+              cpu: 0.5
+              memory: 1Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
               cpu: 0.25
               memory: 0.5Gi
         scale:
-          min_replicas: 0
-          max_replicas: 2
+          min_replicas: 1
+          max_replicas: 3
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
         tags:
           role: integration
       register: app_idem
 
-    - name: Assert container app idempotent
+    - name: Assert app idempotent
       ansible.builtin.assert:
         that:
           - app_idem is not changed
 
-    - name: Update container app scale + tags
+    - name: Container app update scale and tags
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         location: eastus2
         environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: SystemAssigned
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
         ingress:
           external: true
           target_port: 80
           transport: auto
+          allow_insecure: false
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: true
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v2
+        termination_grace_period_seconds: 30
         containers:
           - name: hello
             image: mcr.microsoft.com/k8se/quickstart:latest
             resources:
+              cpu: 0.5
+              memory: 1Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
               cpu: 0.25
               memory: 0.5Gi
         scale:
-          min_replicas: 1
-          max_replicas: 3
+          min_replicas: 2
+          max_replicas: 5
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
         tags:
           role: integration
           updated: "true"
-      register: app_update
+      register: app_update_scale
 
-    - name: Assert container app scale/tag update reported change
+    - name: Assert app scale and tags update
       ansible.builtin.assert:
         that:
-          - app_update is changed
-          - app_update.state.tags.updated == "true"
+          - app_update_scale is changed
+          - app_update_scale.state.template.scale.min_replicas == 2
+          - app_update_scale.state.template.scale.max_replicas == 5
+          - app_update_scale.state.tags.updated == "true"
 
-    - name: Update container app scale + tags again (idempotence)
+    - name: Container app update ingress and dapr
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         location: eastus2
         environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: SystemAssigned
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
         ingress:
           external: true
-          target_port: 80
-          transport: auto
+          target_port: 8080
+          transport: http
+          allow_insecure: true
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: false
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v3
+        termination_grace_period_seconds: 30
         containers:
           - name: hello
             image: mcr.microsoft.com/k8se/quickstart:latest
             resources:
+              cpu: 0.5
+              memory: 1Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
               cpu: 0.25
               memory: 0.5Gi
         scale:
-          min_replicas: 1
-          max_replicas: 3
+          min_replicas: 2
+          max_replicas: 5
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
         tags:
           role: integration
           updated: "true"
-      register: app_update_idem
+      register: app_update_ingress
 
-    - name: Assert container app update idempotent
+    - name: Assert app ingress and dapr update
       ansible.builtin.assert:
         that:
-          - app_update_idem is not changed
+          - app_update_ingress is changed
+          - app_update_ingress.state.configuration.ingress.target_port == 8080
+          - app_update_ingress.state.configuration.ingress.transport | lower == "http"
+          - app_update_ingress.state.configuration.ingress.allow_insecure == true
+          - app_update_ingress.state.configuration.dapr.enabled == false
 
-    - name: Fetch container app via info (by name)
+    - name: Container app update image and identity to UserAssigned
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "{{ app_name }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        workload_profile_name: Consumption
+        identity:
+          type: UserAssigned
+          user_assigned_identities:
+            id:
+              - "{{ umi_id }}"
+            append: false
+        active_revisions_mode: Multiple
+        secrets:
+          - name: my-secret
+            value: super-secret-value
+          - name: api-token
+            value: token-xyz
+        ingress:
+          external: true
+          target_port: 8080
+          transport: http
+          allow_insecure: true
+          client_certificate_mode: ignore
+          ip_security_restrictions:
+            - name: allow-all
+              description: allow all
+              ip_address_range: 0.0.0.0/0
+              action: Allow
+          cors_policy:
+            allowed_origins:
+              - "https://example.com"
+            allowed_methods:
+              - GET
+              - POST
+        dapr:
+          enabled: false
+          app_id: hello-dapr
+          app_protocol: http
+          app_port: 80
+          log_level: info
+          enable_api_logging: true
+        max_inactive_revisions: 5
+        revision_suffix: v4
+        termination_grace_period_seconds: 30
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.75
+              memory: 1.5Gi
+            env:
+              - name: PLAIN_VAR
+                value: plain-updated
+              - name: SECRET_VAR
+                secret_ref: my-secret
+            probes:
+              - type: Liveness
+                http_get:
+                  path: /
+                  port: 80
+                  scheme: HTTP
+                initial_delay_seconds: 5
+                period_seconds: 20
+            volume_mounts:
+              - volume_name: scratch
+                mount_path: /scratch
+        init_containers:
+          - name: init-hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            command:
+              - /bin/sh
+            args:
+              - "-c"
+              - "echo init done"
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 2
+          max_replicas: 5
+          cooldown_period: 30
+          polling_interval: 15
+          rules:
+            - name: http-rule
+              http:
+                metadata:
+                  concurrentRequests: "10"
+        volumes:
+          - name: scratch
+            storage_type: EmptyDir
+        tags:
+          role: integration
+          updated: "true"
+      register: app_update_identity
+
+    - name: Assert app identity switch and container update
+      ansible.builtin.assert:
+        that:
+          - app_update_identity is changed
+          - app_update_identity.state.identity.type == "UserAssigned"
+          - app_update_identity.state.identity.user_assigned_identities | length >= 1
+          - app_update_identity.state.template.revision_suffix == "v4"
+          - app_update_identity.state.template.containers[0].resources.cpu == 0.75
+
+    - name: Container app info by name
       azure.azcollection.azure_rm_containerapp_info:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
       register: app_info
 
-    - name: Assert app info returns exactly one entry with expected fields
+    - name: Assert app info single entry
       ansible.builtin.assert:
         that:
           - app_info.container_apps | length == 1
-          - app_info.container_apps[0].name == "app-aca-" ~ rpfx
+          - app_info.container_apps[0].name == app_name
           - app_info.container_apps[0].provisioning_state == "Succeeded"
-          - app_info.container_apps[0].configuration.ingress.target_port == 80
+          - app_info.container_apps[0].configuration.ingress.target_port == 8080
+          - app_info.container_apps[0].configuration.secrets | length == 2
+          - app_info.container_apps[0].configuration.secrets[0].value is not defined or app_info.container_apps[0].configuration.secrets[0].value is none
+          - app_info.container_apps[0].secrets is not defined
 
-    - name: List all container apps in the resource group
+    - name: Container app info with show_secrets
       azure.azcollection.azure_rm_containerapp_info:
         resource_group: "{{ resource_group }}-containerapp"
-      register: app_list
+        name: "{{ app_name }}"
+        show_secrets: true
+      register: app_info_secrets
 
-    - name: Assert app list contains the test app
+    - name: Assert app info returns secrets
       ansible.builtin.assert:
         that:
-          - app_list.container_apps | length >= 1
-          - "'app-aca-' ~ rpfx in (app_list.container_apps | map(attribute='name') | list)"
+          - app_info_secrets.container_apps | length == 1
+          - app_info_secrets.container_apps[0].secrets is defined
+          - app_info_secrets.container_apps[0].secrets | length == 2
+          - (app_info_secrets.container_apps[0].secrets | map(attribute='name') | list | sort) == ['api-token', 'my-secret']
 
-    - name: Wait until container app reports Running before stopping
+    - name: Container app info list by resource group
       azure.azcollection.azure_rm_containerapp_info:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+      register: app_list_rg
+
+    - name: Assert app list by RG contains app
+      ansible.builtin.assert:
+        that:
+          - app_list_rg.container_apps | length >= 1
+          - app_name in (app_list_rg.container_apps | map(attribute='name') | list)
+
+    - name: Container app info tag filter match
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        tags:
+          - "role:integration"
+      register: app_tag_match
+
+    - name: Assert app tag filter match
+      ansible.builtin.assert:
+        that:
+          - app_tag_match.container_apps | length >= 1
+          - app_name in (app_tag_match.container_apps | map(attribute='name') | list)
+
+    - name: Container app info tag filter miss
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        tags:
+          - "role:nonexistent-tag-value"
+      register: app_tag_miss
+
+    - name: Assert app tag filter empty
+      ansible.builtin.assert:
+        that:
+          - app_tag_miss.container_apps | length == 0
+
+    - name: Container app info by name not found
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "does-not-exist-{{ rpfx }}"
+      register: app_missing
+
+    - name: Assert app info empty on missing
+      ansible.builtin.assert:
+        that:
+          - app_missing.container_apps | length == 0
+
+    - name: Wait for container app running
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "{{ app_name }}"
       register: app_status
-      until: (app_status.container_apps | length > 0) and (app_status.container_apps[0].running_status | default('')) == 'Running'
+      until: (app_status.container_apps | length > 0) and ((app_status.container_apps[0].running_status | default('')) == 'Running')
       retries: 30
       delay: 10
 
-    - name: Stop container app
+    - name: Container app stop
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         status: stop
       register: app_stop
 
-    - name: Assert stop reported change
+    - name: Assert app stop changed
       ansible.builtin.assert:
         that:
           - app_stop is changed
 
-    - name: Stop container app again (idempotence)
+    - name: Container app stop (idempotence)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         status: stop
       register: app_stop_idem
 
-    - name: Assert stop idempotent
+    - name: Assert app stop idempotent
       ansible.builtin.assert:
         that:
           - app_stop_idem is not changed
 
-    - name: Start container app
+    - name: Container app start
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         status: start
       register: app_start
 
-    - name: Assert start reported change
+    - name: Assert app start changed
       ansible.builtin.assert:
         that:
           - app_start is changed
 
-    - name: Start container app again (idempotence)
+    - name: Container app start (idempotence)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         status: start
       register: app_start_idem
 
-    - name: Assert start idempotent
+    - name: Assert app start idempotent
       ansible.builtin.assert:
         that:
           - app_start_idem is not changed
 
-    - name: Delete container app (check mode)
+    - name: Container app delete (check mode)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         state: absent
       check_mode: true
       register: app_delete_check
 
-    - name: Assert container app delete check mode reported change
+    - name: Assert app delete check mode changed
       ansible.builtin.assert:
         that:
           - app_delete_check is changed
 
-    - name: Delete container app
+    - name: Container app delete
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         state: absent
       register: app_delete
 
-    - name: Assert container app deleted
+    - name: Assert app deleted
       ansible.builtin.assert:
         that:
           - app_delete is changed
 
-    - name: Delete container app again (idempotence)
+    - name: Container app delete (idempotence)
       azure.azcollection.azure_rm_containerapp:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "app-aca-{{ rpfx }}"
+        name: "{{ app_name }}"
         state: absent
-      register: app_delete_again
+      register: app_delete_idem
 
     - name: Assert app delete idempotent
       ansible.builtin.assert:
         that:
-          - app_delete_again is not changed
+          - app_delete_idem is not changed
 
-    - name: Delete managed environment
+    - name: Environment delete (check mode)
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
+        state: absent
+      check_mode: true
+      register: env_delete_check
+
+    - name: Assert env delete check mode changed
+      ansible.builtin.assert:
+        that:
+          - env_delete_check is changed
+
+    - name: Environment delete
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "{{ env_name }}"
         state: absent
       register: env_delete
 
-    - name: Assert environment deleted
+    - name: Assert env deleted
       ansible.builtin.assert:
         that:
           - env_delete is changed
 
-    - name: Delete managed environment again (idempotence)
+    - name: Environment delete (idempotence)
       azure.azcollection.azure_rm_containerappenvironment:
         resource_group: "{{ resource_group }}-containerapp"
-        name: "env-aca-{{ rpfx }}"
+        name: "{{ env_name }}"
         state: absent
-      register: env_delete_again
+      register: env_delete_idem
 
-    - name: Assert environment delete idempotent
+    - name: Assert env delete idempotent
       ansible.builtin.assert:
         that:
-          - env_delete_again is not changed
+          - env_delete_idem is not changed
 
   always:
-    - name: Force delete the resource group
+    - name: Force delete test resource group
       azure.azcollection.azure_rm_resourcegroup:
         name: "{{ resource_group }}-containerapp"
         force_delete_nonempty: true

--- a/tests/integration/targets/azure_rm_containerapp/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_containerapp/tasks/main.yml
@@ -1,0 +1,431 @@
+- name: Create a new resource group for container app test
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}-containerapp"
+    location: eastus2
+
+- name: For container app test
+  block:
+    - name: Prepare random suffix for names
+      ansible.builtin.set_fact:
+        rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}"
+      run_once: true
+
+    - name: Create Log Analytics workspace for the environment
+      azure.azcollection.azure_rm_loganalyticsworkspace:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "law-aca-{{ rpfx }}"
+        location: eastus2
+        sku: PerGB2018
+        retention_in_days: 30
+      register: law
+
+    - name: Fetch workspace shared keys
+      azure.azcollection.azure_rm_loganalyticsworkspace_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "law-aca-{{ rpfx }}"
+        show_shared_keys: true
+      register: law_keys
+
+    - name: Create Container Apps managed environment (check mode)
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        location: eastus2
+        app_logs_configuration:
+          destination: log-analytics
+          log_analytics_configuration:
+            customer_id: "{{ law.state.customer_id }}"
+            shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        tags:
+          role: integration
+      check_mode: true
+      register: env_check
+
+    - name: Assert environment check mode reported change
+      ansible.builtin.assert:
+        that:
+          - env_check is changed
+          - env_check.state == {} or env_check.state is defined
+
+    - name: Create Container Apps managed environment
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        location: eastus2
+        app_logs_configuration:
+          destination: log-analytics
+          log_analytics_configuration:
+            customer_id: "{{ law.state.customer_id }}"
+            shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        tags:
+          role: integration
+      register: env_create
+
+    - name: Assert environment created
+      ansible.builtin.assert:
+        that:
+          - env_create is changed
+          - env_create.state.id is defined
+          - env_create.state.name == "env-aca-" ~ rpfx
+          - env_create.state.provisioning_state == "Succeeded"
+
+    - name: Create environment again (idempotence)
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        location: eastus2
+        app_logs_configuration:
+          destination: log-analytics
+          log_analytics_configuration:
+            customer_id: "{{ law.state.customer_id }}"
+            shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        tags:
+          role: integration
+      register: env_idem
+
+    - name: Assert environment idempotent
+      ansible.builtin.assert:
+        that:
+          - env_idem is not changed
+
+    - name: Update environment tags
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        location: eastus2
+        app_logs_configuration:
+          destination: log-analytics
+          log_analytics_configuration:
+            customer_id: "{{ law.state.customer_id }}"
+            shared_key: "{{ law_keys.workspaces[0].shared_keys.primary_shared_key }}"
+        tags:
+          role: integration
+          updated: "true"
+      register: env_update
+
+    - name: Assert environment tag update reported change
+      ansible.builtin.assert:
+        that:
+          - env_update is changed
+          - env_update.state.tags.updated == "true"
+
+    - name: Fetch environment via info module (by name)
+      azure.azcollection.azure_rm_containerappenvironment_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+      register: env_info
+
+    - name: Assert env info returns exactly one entry
+      ansible.builtin.assert:
+        that:
+          - env_info.managed_environments | length == 1
+          - env_info.managed_environments[0].name == "env-aca-" ~ rpfx
+          - env_info.managed_environments[0].provisioning_state == "Succeeded"
+
+    - name: List all environments in the resource group
+      azure.azcollection.azure_rm_containerappenvironment_info:
+        resource_group: "{{ resource_group }}-containerapp"
+      register: env_list
+
+    - name: Assert env list contains the test environment
+      ansible.builtin.assert:
+        that:
+          - env_list.managed_environments | length >= 1
+          - "'env-aca-' ~ rpfx in (env_list.managed_environments | map(attribute='name') | list)"
+
+    - name: Create container app (check mode)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        ingress:
+          external: true
+          target_port: 80
+          transport: auto
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 0
+          max_replicas: 2
+        tags:
+          role: integration
+      check_mode: true
+      register: app_check
+
+    - name: Assert container app check mode reported change
+      ansible.builtin.assert:
+        that:
+          - app_check is changed
+
+    - name: Create container app
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        ingress:
+          external: true
+          target_port: 80
+          transport: auto
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 0
+          max_replicas: 2
+        tags:
+          role: integration
+      register: app_create
+
+    - name: Assert container app created
+      ansible.builtin.assert:
+        that:
+          - app_create is changed
+          - app_create.state.id is defined
+          - app_create.state.name == "app-aca-" ~ rpfx
+          - app_create.state.provisioning_state == "Succeeded"
+
+    - name: Create container app again (idempotence)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        ingress:
+          external: true
+          target_port: 80
+          transport: auto
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 0
+          max_replicas: 2
+        tags:
+          role: integration
+      register: app_idem
+
+    - name: Assert container app idempotent
+      ansible.builtin.assert:
+        that:
+          - app_idem is not changed
+
+    - name: Update container app scale + tags
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        ingress:
+          external: true
+          target_port: 80
+          transport: auto
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 1
+          max_replicas: 3
+        tags:
+          role: integration
+          updated: "true"
+      register: app_update
+
+    - name: Assert container app scale/tag update reported change
+      ansible.builtin.assert:
+        that:
+          - app_update is changed
+          - app_update.state.tags.updated == "true"
+
+    - name: Update container app scale + tags again (idempotence)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        location: eastus2
+        environment_id: "{{ env_create.state.id }}"
+        ingress:
+          external: true
+          target_port: 80
+          transport: auto
+        containers:
+          - name: hello
+            image: mcr.microsoft.com/k8se/quickstart:latest
+            resources:
+              cpu: 0.25
+              memory: 0.5Gi
+        scale:
+          min_replicas: 1
+          max_replicas: 3
+        tags:
+          role: integration
+          updated: "true"
+      register: app_update_idem
+
+    - name: Assert container app update idempotent
+      ansible.builtin.assert:
+        that:
+          - app_update_idem is not changed
+
+    - name: Fetch container app via info (by name)
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+      register: app_info
+
+    - name: Assert app info returns exactly one entry with expected fields
+      ansible.builtin.assert:
+        that:
+          - app_info.container_apps | length == 1
+          - app_info.container_apps[0].name == "app-aca-" ~ rpfx
+          - app_info.container_apps[0].provisioning_state == "Succeeded"
+          - app_info.container_apps[0].configuration.ingress.target_port == 80
+
+    - name: List all container apps in the resource group
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+      register: app_list
+
+    - name: Assert app list contains the test app
+      ansible.builtin.assert:
+        that:
+          - app_list.container_apps | length >= 1
+          - "'app-aca-' ~ rpfx in (app_list.container_apps | map(attribute='name') | list)"
+
+    - name: Wait until container app reports Running before stopping
+      azure.azcollection.azure_rm_containerapp_info:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+      register: app_status
+      until: (app_status.container_apps | length > 0) and (app_status.container_apps[0].running_status | default('')) == 'Running'
+      retries: 30
+      delay: 10
+
+    - name: Stop container app
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        status: stop
+      register: app_stop
+
+    - name: Assert stop reported change
+      ansible.builtin.assert:
+        that:
+          - app_stop is changed
+
+    - name: Stop container app again (idempotence)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        status: stop
+      register: app_stop_idem
+
+    - name: Assert stop idempotent
+      ansible.builtin.assert:
+        that:
+          - app_stop_idem is not changed
+
+    - name: Start container app
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        status: start
+      register: app_start
+
+    - name: Assert start reported change
+      ansible.builtin.assert:
+        that:
+          - app_start is changed
+
+    - name: Start container app again (idempotence)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        status: start
+      register: app_start_idem
+
+    - name: Assert start idempotent
+      ansible.builtin.assert:
+        that:
+          - app_start_idem is not changed
+
+    - name: Delete container app (check mode)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        state: absent
+      check_mode: true
+      register: app_delete_check
+
+    - name: Assert container app delete check mode reported change
+      ansible.builtin.assert:
+        that:
+          - app_delete_check is changed
+
+    - name: Delete container app
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        state: absent
+      register: app_delete
+
+    - name: Assert container app deleted
+      ansible.builtin.assert:
+        that:
+          - app_delete is changed
+
+    - name: Delete container app again (idempotence)
+      azure.azcollection.azure_rm_containerapp:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "app-aca-{{ rpfx }}"
+        state: absent
+      register: app_delete_again
+
+    - name: Assert app delete idempotent
+      ansible.builtin.assert:
+        that:
+          - app_delete_again is not changed
+
+    - name: Delete managed environment
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        state: absent
+      register: env_delete
+
+    - name: Assert environment deleted
+      ansible.builtin.assert:
+        that:
+          - env_delete is changed
+
+    - name: Delete managed environment again (idempotence)
+      azure.azcollection.azure_rm_containerappenvironment:
+        resource_group: "{{ resource_group }}-containerapp"
+        name: "env-aca-{{ rpfx }}"
+        state: absent
+      register: env_delete_again
+
+    - name: Assert environment delete idempotent
+      ansible.builtin.assert:
+        that:
+          - env_delete_again is not changed
+
+  always:
+    - name: Force delete the resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ resource_group }}-containerapp"
+        force_delete_nonempty: true
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Adds first-class Ansible support for Azure Container Apps by introducing four new modules — `azure_rm_containerappenvironment` and `azure_rm_containerapp` for CRUD, plus their `_info` counterparts — targeting `azure-mgmt-appcontainers` 5.0.0 (API version 2024-03-01). Users can now create, update, start, stop, and delete container apps and their managed environments without falling back to `azure_rm_resource`. The modules follow the established `azure_rm_keyvault` 14.0.1 hybrid-model pattern: they construct explicit SDK model instances so ARM receives the required `properties`-envelope wire shape, and use `azure.core.serialization.as_attribute_dict` on responses so returned state is snake_case and flat.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [x] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_containerappenvironment.py
- plugins/modules/azure_rm_containerappenvironment_info.py
- plugins/modules/azure_rm_containerapp.py
- plugins/modules/azure_rm_containerapp_info.py
- plugins/module_utils/azure_rm_common.py
- meta/runtime.yml
- pr-pipelines.yml
- requirements.txt
- tests/integration/targets/azure_rm_containerapp/aliases
- tests/integration/targets/azure_rm_containerapp/meta/main.yml
- tests/integration/targets/azure_rm_containerapp/tasks/main.yml

##### ADDITIONAL INFORMATION
- Managed environment CRUD via `azure_rm_containerappenvironment`: supports VNet configuration, workload profiles, Log Analytics destination, peer authentication (mTLS), peer traffic encryption, public network access, infrastructure resource group, and zone redundancy.
- Container app CRUD via `azure_rm_containerapp`: full `template` (containers and init containers with probes, env, resources, volume mounts), `configuration` (secrets, registries, ingress with traffic weights and custom domains, Dapr), `scale` with polymorphic rules (HTTP, TCP, Azure Queue, custom), managed identity (system and user-assigned), and `status: start` / `status: stop` lifecycle actions.
- Info modules support single-name lookup and resource-group list. `azure_rm_containerapp_info` optionally calls `list_secrets` and registers the returned values with `module.no_log_values` to prevent log leakage.
- Payload construction uses explicit `azure-mgmt-appcontainers` typed model instances (`ContainerApp`, `ManagedEnvironment`, `Configuration`, `Template`, `Ingress`, `Scale`, `Container`, etc.) so ARM receives resource fields nested under `properties` with correct camelCase serialization; mirrors the pattern already established by `azure_rm_keyvault` after its 14.0.1 migration.
- Response normalization uses `azure.core.serialization.as_attribute_dict`, the Azure SDK's official backcompat helper for hybrid/typed models.
- `azure-mgmt-appcontainers==5.0.0` added to `requirements.txt`; `containerapps_client` accessor added to `plugins/module_utils/azure_rm_common.py` with API version pinned to `2024-03-01` (SDK stable default).
- `meta/runtime.yml` registers the four new modules in `action_groups.azure`; `pr-pipelines.yml` gains an `azure_rm_containerapp` matrix entry.
- Integration test target follows the `azure_rm_mysqlflexibleserver` layout: dedicated `{{ resource_group }}-containerapp` RG, `block:` with `always:` force-delete cleanup, and check-mode / create / idempotence / update / info / start-stop / delete coverage with idempotence assertions on each mutating path.

##### REFERENCE
- https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/appcontainers/azure-mgmt-appcontainers
- https://github.com/Azure/azure-rest-api-specs/tree/main/specification/app/resource-manager/Microsoft.App/stable/2024-03-01