### PR TITLE
Aks load balancer profile

### DIFF
--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -1704,13 +1704,17 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                     if self.network_profile:
                         for key in self.network_profile.keys():
                             original = response['network_profile'].get(key) or ''
-                            if isinstance(original, dict):
-                                if not self.default_compare({}, self.network_profile[key], original, '', dict(compare=[])):
-                                    to_be_updated = True
+                            requested = self.network_profile.get(key) or ''
+                            if requested:
+                                if isinstance(original, dict):
+                                    if isinstance(requested, dict) and \
+                                            not self.default_compare({}, requested, original, '', dict(compare=[])):
+                                        to_be_updated = True
+                                    else:
+                                        self.network_profile[key] = original
                                 else:
-                                    self.network_profile[key] = original
-                            elif self.network_profile[key] and self.network_profile[key].lower() != original.lower():
-                                to_be_updated = True
+                                    if requested.lower() != original.lower():
+                                        to_be_updated = True
 
                     def compare_addon(origin, patch, config):
                         if not patch:

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -1705,16 +1705,19 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                         for key in self.network_profile.keys():
                             original = response['network_profile'].get(key) or ''
                             requested = self.network_profile.get(key) or ''
-                            if requested:
-                                if isinstance(original, dict):
-                                    if isinstance(requested, dict) and \
-                                            not self.default_compare({}, requested, original, '', dict(compare=[])):
-                                        to_be_updated = True
-                                    else:
-                                        self.network_profile[key] = original
+
+                            if not requested:
+                                continue
+
+                            if isinstance(requested, dict):
+                                if not isinstance(original, dict):
+                                    to_be_updated = True
+                                elif not self.default_compare({}, requested, original, '', dict(compare=[])):
+                                    to_be_updated = True
                                 else:
-                                    if requested.lower() != original.lower():
-                                        to_be_updated = True
+                                    self.network_profile[key] = original
+                            elif requested.lower() != original.lower():
+                                to_be_updated = True
 
                     def compare_addon(origin, patch, config):
                         if not patch:

--- a/plugins/modules/azure_rm_aks.py
+++ b/plugins/modules/azure_rm_aks.py
@@ -409,6 +409,22 @@ options:
                     - userDefinedRouting
                     - managedNATGateway
                     - userAssignedNATGateway
+            load_balancer_profile:
+                description:
+                    - Configuration profile for the Azure Load Balancer.
+                type: dict
+                version_added: '4.0.0'
+                suboptions:
+                    backend_pool_type:
+                        description:
+                            - Specifies how nodes are added to the Load Balancer backend pool.
+                            - C(nodeIP) uses the node IP address as the backend pool member.
+                            - C(nodeIPConfiguration) uses the node network interface IP configuration.
+                        type: str
+                        choices:
+                            - nodeIP
+                            - nodeIPConfiguration
+                        required: false
     api_server_access_profile:
         description:
             - Profile of API Access configuration.
@@ -1052,7 +1068,8 @@ def create_network_profiles_dict(network):
         service_cidr=network.service_cidr,
         dns_service_ip=network.dns_service_ip,
         load_balancer_sku=network.load_balancer_sku,
-        outbound_type=network.outbound_type
+        outbound_type=network.outbound_type,
+        load_balancer_profile=network.load_balancer_profile.as_dict() if network.load_balancer_profile else None
     ) if network else dict()
 
 
@@ -1316,7 +1333,16 @@ network_profile_spec = dict(
     service_cidr=dict(type='str'),
     dns_service_ip=dict(type='str'),
     load_balancer_sku=dict(type='str', choices=['standard', 'basic']),
-    outbound_type=dict(type='str', default='loadBalancer', choices=['userDefinedRouting', 'loadBalancer', 'userAssignedNATGateway', 'managedNATGateway'])
+    outbound_type=dict(type='str', default='loadBalancer', choices=['userDefinedRouting', 'loadBalancer', 'userAssignedNATGateway', 'managedNATGateway']),
+    load_balancer_profile=dict(
+        type='dict',
+        options=dict(
+            backend_pool_type=dict(
+                type='str',
+                choices=['nodeIP', 'nodeIPConfiguration']
+            )
+        )
+    ),
 )
 
 
@@ -1678,7 +1704,12 @@ class AzureRMManagedCluster(AzureRMModuleBaseExt):
                     if self.network_profile:
                         for key in self.network_profile.keys():
                             original = response['network_profile'].get(key) or ''
-                            if self.network_profile[key] and self.network_profile[key].lower() != original.lower():
+                            if isinstance(original, dict):
+                                if not self.default_compare({}, self.network_profile[key], original, '', dict(compare=[])):
+                                    to_be_updated = True
+                                else:
+                                    self.network_profile[key] = original
+                            elif self.network_profile[key] and self.network_profile[key].lower() != original.lower():
                                 to_be_updated = True
 
                     def compare_addon(origin, patch, config):

--- a/tests/integration/targets/azure_rm_aks/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_aks/tasks/main.yml
@@ -307,6 +307,113 @@
         that:
           - output is not changed
 
+    - name: Configure load balancer backend pool type to nodeIP
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+            max_pods: 42
+            availability_zones:
+              - 1
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+          load_balancer_profile:
+            backend_pool_type: nodeIP
+      register: output
+
+    - name: Assert load balancer profile is nodeIP
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.network_profile.load_balancer_profile.backend_pool_type == 'nodeIP'
+
+    - name: Configure load balancer backend pool type to nodeIP (idempotent)
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+            max_pods: 42
+            availability_zones:
+              - 1
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+          load_balancer_profile:
+            backend_pool_type: nodeIP
+      register: output
+
+    - name: Assert idempotent
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Configure load balancer backend pool type to nodeIPConfiguration
+      azure.azcollection.azure_rm_aks:
+        name: "aks{{ rpfx }}"
+        resource_group: "{{ resource_group }}-aks"
+        location: "{{ location }}"
+        dns_prefix: "aks{{ rpfx }}"
+        aad_profile:
+          managed: true
+          enable_azure_rbac: true
+        disable_local_accounts: true
+        kubernetes_version: "{{ versions.azure_aks_versions[0] }}"
+        service_principal:
+          client_id: "{{ azure_client_id }}"
+        agent_pool_profiles:
+          - name: default
+            count: 1
+            vm_size: Standard_D2s_v3
+            type: VirtualMachineScaleSets
+            mode: System
+            max_pods: 42
+            availability_zones:
+              - 1
+        node_resource_group: "node{{ noderpfx }}"
+        enable_rbac: true
+        network_profile:
+          load_balancer_sku: standard
+          load_balancer_profile:
+            backend_pool_type: nodeIPConfiguration
+      register: output
+
+    - name: Assert load balancer profile is nodeIPConfiguration
+      ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.network_profile.load_balancer_profile.backend_pool_type == 'nodeIPConfiguration'
+
     - name: Get available version
       azure.azcollection.azure_rm_aksversion_info:
         location: "{{ location }}"


### PR DESCRIPTION
##### SUMMARY

Add support for configuring the Azure Load Balancer backend pool type in `azure_rm_aks`.

This allows users to configure the AKS Load Balancer backend pool using either `nodeIP` or `nodeIPConfiguration`.

Example:

```yaml
network_profile:
  load_balancer_sku: standard
  load_balancer_profile:
    backend_pool_type: nodeIP
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_aks

##### ADDITIONAL INFORMATION
Before:
```yaml
network_profile:
  load_balancer_sku: standard
```
After:
```yaml
network_profile:
  load_balancer_sku: standard
  load_balancer_profile:
    backend_pool_type: nodeIP
```