### PR TITLE
Fix 2351: replace deprecated ansible.module_utils._text imports

### DIFF
--- a/plugins/inventory/azure_kql.py
+++ b/plugins/inventory/azure_kql.py
@@ -107,7 +107,7 @@ import re
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.errors import AnsibleError
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from os import environ
 

--- a/plugins/inventory/azure_rm.py
+++ b/plugins/inventory/azure_rm.py
@@ -159,7 +159,7 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible.errors import AnsibleParserError, AnsibleError
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils._text import to_native, to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible.utils.display import Display
 from itertools import chain
 from os import environ

--- a/plugins/lookup/azure_service_principal_attribute.py
+++ b/plugins/lookup/azure_service_principal_attribute.py
@@ -60,7 +60,7 @@ _raw:
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMAuth
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import asyncio

--- a/plugins/modules/azure_rm_autoscale.py
+++ b/plugins/modules/azure_rm_autoscale.py
@@ -446,7 +446,7 @@ state:
 '''  # NOQA
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import timedelta
 
 try:

--- a/plugins/modules/azure_rm_autoscale_info.py
+++ b/plugins/modules/azure_rm_autoscale_info.py
@@ -129,7 +129,7 @@ autoscales:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # duplicated in azure_rm_autoscale

--- a/plugins/modules/azure_rm_dnszone.py
+++ b/plugins/modules/azure_rm_dnszone.py
@@ -119,7 +119,7 @@ state:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_dnszone_info.py
+++ b/plugins/modules/azure_rm_dnszone_info.py
@@ -127,7 +127,7 @@ dnszones:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_loadbalancer.py
+++ b/plugins/modules/azure_rm_loadbalancer.py
@@ -448,7 +448,7 @@ changed:
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import format_resource_id
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 try:
     from azure.core.exceptions import ResourceNotFoundError
     from azure.mgmt.core.tools import parse_resource_id

--- a/plugins/modules/azure_rm_networkinterface.py
+++ b/plugins/modules/azure_rm_networkinterface.py
@@ -487,7 +487,7 @@ from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common
                                                                                          normalize_location_name,
                                                                                          format_resource_id
                                                                                          )
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def subnet_to_dict(subnet):

--- a/plugins/modules/azure_rm_publicipaddress.py
+++ b/plugins/modules/azure_rm_publicipaddress.py
@@ -260,7 +260,7 @@ state:
 '''
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from azure.core.exceptions import ResourceNotFoundError

--- a/plugins/modules/azure_rm_roledefinition.py
+++ b/plugins/modules/azure_rm_roledefinition.py
@@ -104,7 +104,7 @@ id:
 '''
 
 import uuid
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase

--- a/plugins/modules/azure_rm_securitygroup.py
+++ b/plugins/modules/azure_rm_securitygroup.py
@@ -538,7 +538,7 @@ except ImportError:
     pass
 
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def validate_rule(self, rule, rule_type=None):

--- a/plugins/modules/azure_rm_servicebus.py
+++ b/plugins/modules/azure_rm_servicebus.py
@@ -118,7 +118,7 @@ except ImportError:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebus_info.py
+++ b/plugins/modules/azure_rm_servicebus_info.py
@@ -406,7 +406,7 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 from ansible.module_utils.common.dict_transformations import _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 duration_spec_map = dict(

--- a/plugins/modules/azure_rm_servicebusqueue.py
+++ b/plugins/modules/azure_rm_servicebusqueue.py
@@ -150,7 +150,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebustopic.py
+++ b/plugins/modules/azure_rm_servicebustopic.py
@@ -128,7 +128,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_servicebustopicsubscription.py
+++ b/plugins/modules/azure_rm_servicebustopicsubscription.py
@@ -139,7 +139,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel, _camel_to_snake
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from datetime import datetime, timedelta
 
 

--- a/plugins/modules/azure_rm_storageaccount.py
+++ b/plugins/modules/azure_rm_storageaccount.py
@@ -933,7 +933,7 @@ import copy
 import time
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AZURE_SUCCESS_STATE
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import env_fallback
 
 try:

--- a/plugins/modules/azure_rm_storageaccount_info.py
+++ b/plugins/modules/azure_rm_storageaccount_info.py
@@ -653,7 +653,7 @@ storageaccounts:
 
 try:
     from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-    from ansible.module_utils._text import to_native
+    from ansible.module_utils.common.text.converters import to_native
     from ansible.module_utils.basic import env_fallback
     from azure.core.serialization import as_attribute_dict
 except ImportError:


### PR DESCRIPTION
##### SUMMARY
Fix #2351.
Replaces the deprecated `from ansible.module_utils._text import ...` shim with the canonical `from ansible.module_utils.common.text.converters import ...` across all 19 sites in the collection (2 inventory plugins, 1 lookup plugin, 16 modules). The re-export is call-signature-compatible, so no runtime behavior changes; this removes the `DeprecationWarning` emitted by ansible-core 2.20 and prevents breakage in ansible-core 2.24 when the `_text` shim is removed.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [ ] New Module Pull Request
- [x] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/inventory/azure_rm.py
- plugins/inventory/azure_kql.py
- plugins/lookup/azure_service_principal_attribute.py
- plugins/modules/azure_rm_autoscale.py
- plugins/modules/azure_rm_autoscale_info.py
- plugins/modules/azure_rm_dnszone.py
- plugins/modules/azure_rm_dnszone_info.py
- plugins/modules/azure_rm_loadbalancer.py
- plugins/modules/azure_rm_networkinterface.py
- plugins/modules/azure_rm_publicipaddress.py
- plugins/modules/azure_rm_roledefinition.py
- plugins/modules/azure_rm_securitygroup.py
- plugins/modules/azure_rm_servicebus.py
- plugins/modules/azure_rm_servicebus_info.py
- plugins/modules/azure_rm_servicebusqueue.py
- plugins/modules/azure_rm_servicebustopic.py
- plugins/modules/azure_rm_servicebustopicsubscription.py
- plugins/modules/azure_rm_storageaccount.py
- plugins/modules/azure_rm_storageaccount_info.py

##### ADDITIONAL INFORMATION
- Loading any of the 19 affected modules or plugins under ansible-core 2.20 no longer emits `[DEPRECATION WARNING]: Importing 'to_text'/'to_native'/'to_bytes' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24.`
- Import surface only; `to_native`, `to_text`, and `to_bytes` are re-exported by `ansible.module_utils.common.text.converters` with identical signatures, so call sites, option contracts, return envelopes, and idempotence behavior are unchanged.
- The replacement path `ansible.module_utils.common.text.converters` is the exact target that ansible-core's own `_text` deprecation shim prints in its `help_text` — the shim's `__getattr__` fetches each symbol from `converters` before raising the deprecation warning.

##### REFERENCE
- https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/_text.py