### PR TITLE
New Module 866: Add azure_rm_loadbalancerbackendaddresspool and _info modules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -151,6 +151,8 @@ action_groups:
     - azure.azcollection.azure_rm_keyvaultsecret_info
     - azure.azcollection.azure_rm_loadbalancer
     - azure.azcollection.azure_rm_loadbalancer_info
+    - azure.azcollection.azure_rm_loadbalancerbackendaddresspool
+    - azure.azcollection.azure_rm_loadbalancerbackendaddresspool_info
     - azure.azcollection.azure_rm_localnetworkgateway
     - azure.azcollection.azure_rm_localnetworkgateway_info
     - azure.azcollection.azure_rm_lock

--- a/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
+++ b/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
@@ -1,0 +1,449 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Zun Yang (@zunyangc).
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_loadbalancerbackendaddresspool
+
+version_added: '4.0.0'
+
+short_description: Manage a backend address pool of an Azure load balancer
+
+description:
+    - Create, update or delete a single backend address pool on an existing Azure load balancer.
+    - The parent module M(azure.azcollection.azure_rm_loadbalancer) only declares empty pool stubs by name; this module owns all pool-level properties and members.
+
+options:
+    resource_group:
+        description:
+            - Name of the resource group that contains the load balancer.
+        required: true
+        type: str
+    load_balancer_name:
+        description:
+            - Name of the parent load balancer.
+        required: true
+        type: str
+    name:
+        description:
+            - Name of the backend address pool.
+        required: true
+        type: str
+    state:
+        description:
+            - Assert the state of the backend address pool.
+            - Use C(present) to create or update, or C(absent) to delete.
+        default: present
+        type: str
+        choices:
+            - absent
+            - present
+    virtual_network:
+        description:
+            - Resource ID of the virtual network the backend address pool is bound to.
+            - Required when I(sync_mode) is set.
+        type: str
+    sync_mode:
+        description:
+            - Backend address synchronous mode for the backend pool.
+            - Requires Standard SKU load balancer and I(virtual_network) to be set.
+        type: str
+        choices:
+            - Automatic
+            - Manual
+    drain_period_in_seconds:
+        description:
+            - Seconds the load balancer waits before sending RESET to client and backend address on connection close.
+        type: int
+    tunnel_interfaces:
+        description:
+            - Gateway load balancer tunnel interfaces for the backend address pool.
+        type: list
+        elements: dict
+        suboptions:
+            port:
+                description:
+                    - Port of the gateway load balancer tunnel interface.
+                type: int
+            identifier:
+                description:
+                    - Identifier of the gateway load balancer tunnel interface.
+                type: int
+            protocol:
+                description:
+                    - Protocol of the gateway load balancer tunnel interface.
+                type: str
+                choices:
+                    - None
+                    - Native
+                    - VXLAN
+            type:
+                description:
+                    - Traffic type of the gateway load balancer tunnel interface.
+                type: str
+                choices:
+                    - None
+                    - Internal
+                    - External
+    load_balancer_backend_addresses:
+        description:
+            - Backend addresses (IP-based or NIC-config-based) for the backend pool.
+            - Requires Standard SKU load balancer.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description:
+                    - Name of the backend address, unique within the pool.
+                type: str
+                required: true
+            ip_address:
+                description:
+                    - IP address belonging to the referenced I(virtual_network).
+                type: str
+            virtual_network:
+                description:
+                    - Resource ID of the virtual network the backend address belongs to.
+                type: str
+            subnet:
+                description:
+                    - Resource ID of the subnet the backend address belongs to.
+                type: str
+            network_interface_ip_configuration:
+                description:
+                    - Resource ID of an existing NIC IP configuration to attach to the pool.
+                type: str
+            load_balancer_frontend_ip_configuration:
+                description:
+                    - Resource ID of a regional load balancer frontend IP configuration.
+                    - Used only when attaching a regional load balancer to a Global cross-region load balancer.
+                type: str
+            admin_state:
+                description:
+                    - Administrative state which can override health probe results for this backend address.
+                type: str
+                choices:
+                    - None
+                    - Up
+                    - Down
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Create backend address pool with two IP-based members
+  azure_rm_loadbalancerbackendaddresspool:
+    resource_group: myResourceGroup
+    load_balancer_name: myLoadBalancer
+    name: bepool0
+    load_balancer_backend_addresses:
+      - name: address1
+        ip_address: 10.0.0.10
+        virtual_network: /subscriptions/xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet
+      - name: address2
+        ip_address: 10.0.0.11
+        virtual_network: /subscriptions/xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet
+
+- name: Attach an existing NIC IP configuration to a backend pool
+  azure_rm_loadbalancerbackendaddresspool:
+    resource_group: myResourceGroup
+    load_balancer_name: myLoadBalancer
+    name: bepool0
+    load_balancer_backend_addresses:
+      - name: web-server1-nic
+        network_interface_ip_configuration: /subscriptions/xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/web1-nic/ipConfigurations/ipconfig1
+
+- name: Delete backend address pool
+  azure_rm_loadbalancerbackendaddresspool:
+    resource_group: myResourceGroup
+    load_balancer_name: myLoadBalancer
+    name: bepool0
+    state: absent
+'''
+
+RETURN = '''
+state:
+    description:
+        - Current state of the backend address pool.
+    returned: always
+    type: complex
+    contains:
+        id:
+            description:
+                - Resource ID of the backend address pool.
+            type: str
+            returned: always
+            sample: "/subscriptions/xxx/resourceGroups/myRG/providers/Microsoft.Network/loadBalancers/myLB/backendAddressPools/bepool0"
+        name:
+            description:
+                - Name of the backend address pool.
+            type: str
+            returned: always
+            sample: bepool0
+        provisioning_state:
+            description:
+                - Provisioning state of the backend address pool.
+            type: str
+            returned: always
+            sample: Succeeded
+        virtual_network:
+            description:
+                - Resource ID of the virtual network the pool is bound to.
+            type: str
+            returned: when-used
+            sample: null
+        sync_mode:
+            description:
+                - Backend address synchronous mode.
+            type: str
+            returned: when-used
+            sample: null
+        drain_period_in_seconds:
+            description:
+                - Drain period in seconds.
+            type: int
+            returned: when-used
+            sample: null
+        load_balancer_backend_addresses:
+            description:
+                - List of backend addresses attached to the pool.
+            type: list
+            returned: always
+            sample:
+                - name: address1
+                  ip_address: 10.0.0.10
+                  virtual_network: /subscriptions/xxx/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myVnet
+                  admin_state: None
+        tunnel_interfaces:
+            description:
+                - Gateway load balancer tunnel interfaces.
+            type: list
+            returned: when-used
+            sample: null
+changed:
+    description:
+        - Whether or not the resource has changed.
+    returned: always
+    type: bool
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+
+backend_address_spec = dict(
+    name=dict(type='str', required=True),
+    ip_address=dict(type='str'),
+    virtual_network=dict(type='str'),
+    subnet=dict(type='str'),
+    network_interface_ip_configuration=dict(type='str'),
+    load_balancer_frontend_ip_configuration=dict(type='str'),
+    admin_state=dict(type='str', choices=['None', 'Up', 'Down']),
+)
+
+
+tunnel_interface_spec = dict(
+    port=dict(type='int'),
+    identifier=dict(type='int'),
+    protocol=dict(type='str', choices=['None', 'Native', 'VXLAN']),
+    type=dict(type='str', choices=['None', 'Internal', 'External']),
+)
+
+
+class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            load_balancer_name=dict(type='str', required=True),
+            name=dict(type='str', required=True),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+            virtual_network=dict(type='str'),
+            sync_mode=dict(type='str', choices=['Automatic', 'Manual']),
+            drain_period_in_seconds=dict(type='int'),
+            tunnel_interfaces=dict(type='list', elements='dict', options=tunnel_interface_spec),
+            load_balancer_backend_addresses=dict(type='list', elements='dict', options=backend_address_spec),
+        )
+
+        self.resource_group = None
+        self.load_balancer_name = None
+        self.name = None
+        self.state = None
+        self.virtual_network = None
+        self.sync_mode = None
+        self.drain_period_in_seconds = None
+        self.tunnel_interfaces = None
+        self.load_balancer_backend_addresses = None
+
+        self.results = dict(changed=False, state=None)
+
+        super(AzureRMLoadBalancerBackendAddressPool, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec):
+            setattr(self, key, kwargs[key])
+
+        existing = self.get_backend_address_pool()
+        existing_dict = self.format_item(existing) if existing else None
+        desired = self.build_desired_dict()
+        changed = False
+        response = existing_dict
+
+        if self.state == 'present':
+            if existing is None:
+                changed = True
+                if not self.check_mode:
+                    response = self.create_or_update()
+            else:
+                if not self.default_compare({}, desired, existing_dict, '', dict(compare=[])):
+                    changed = True
+                    if not self.check_mode:
+                        response = self.create_or_update()
+        else:
+            if existing is not None:
+                changed = True
+                if not self.check_mode:
+                    self.delete_backend_address_pool()
+                    response = None
+
+        self.results['changed'] = changed
+        self.results['state'] = response
+        return self.results
+
+    def build_desired_dict(self):
+        return dict(
+            name=self.name,
+            virtual_network=self.virtual_network,
+            sync_mode=self.sync_mode,
+            drain_period_in_seconds=self.drain_period_in_seconds,
+            tunnel_interfaces=self.tunnel_interfaces,
+            load_balancer_backend_addresses=self.load_balancer_backend_addresses,
+        )
+
+    def build_pool_param(self):
+        return self.network_models.BackendAddressPool(
+            name=self.name,
+            virtual_network=self.network_models.SubResource(
+                id=self.virtual_network
+            ) if self.virtual_network else None,
+            sync_mode=self.sync_mode,
+            drain_period_in_seconds=self.drain_period_in_seconds,
+            tunnel_interfaces=[self.network_models.GatewayLoadBalancerTunnelInterface(
+                port=ti.get('port'),
+                identifier=ti.get('identifier'),
+                protocol=ti.get('protocol'),
+                type=ti.get('type'),
+            ) for ti in self.tunnel_interfaces] if self.tunnel_interfaces else None,
+            load_balancer_backend_addresses=[self.network_models.LoadBalancerBackendAddress(
+                name=addr.get('name'),
+                ip_address=addr.get('ip_address'),
+                virtual_network=self.network_models.SubResource(
+                    id=addr.get('virtual_network')
+                ) if addr.get('virtual_network') else None,
+                subnet=self.network_models.SubResource(
+                    id=addr.get('subnet')
+                ) if addr.get('subnet') else None,
+                network_interface_ip_configuration=self.network_models.SubResource(
+                    id=addr.get('network_interface_ip_configuration')
+                ) if addr.get('network_interface_ip_configuration') else None,
+                load_balancer_frontend_ip_configuration=self.network_models.SubResource(
+                    id=addr.get('load_balancer_frontend_ip_configuration')
+                ) if addr.get('load_balancer_frontend_ip_configuration') else None,
+                admin_state=addr.get('admin_state'),
+            ) for addr in self.load_balancer_backend_addresses] if self.load_balancer_backend_addresses else None,
+        )
+
+    def get_backend_address_pool(self):
+        try:
+            return self.network_client.load_balancer_backend_address_pools.get(
+                self.resource_group, self.load_balancer_name, self.name
+            )
+        except ResourceNotFoundError:
+            return None
+
+    def create_or_update(self):
+        param = self.build_pool_param()
+        try:
+            poller = self.network_client.load_balancer_backend_address_pools.begin_create_or_update(
+                self.resource_group, self.load_balancer_name, self.name, param
+            )
+            result = self.get_poller_result(poller)
+            return self.format_item(result)
+        except Exception as exc:
+            self.fail("Error creating or updating backend address pool {0} on load balancer {1} - {2}".format(
+                self.name, self.load_balancer_name, str(exc)))
+
+    def delete_backend_address_pool(self):
+        try:
+            poller = self.network_client.load_balancer_backend_address_pools.begin_delete(
+                self.resource_group, self.load_balancer_name, self.name
+            )
+            self.get_poller_result(poller)
+        except Exception as exc:
+            self.fail("Error deleting backend address pool {0} from load balancer {1} - {2}".format(
+                self.name, self.load_balancer_name, str(exc)))
+
+    def format_item(self, item):
+        if item is None:
+            return None
+        result = dict(
+            id=item.id,
+            name=item.name,
+            provisioning_state=item.provisioning_state,
+            virtual_network=item.virtual_network.id if item.virtual_network is not None else None,
+            sync_mode=item.sync_mode,
+            drain_period_in_seconds=item.drain_period_in_seconds,
+            tunnel_interfaces=None,
+            load_balancer_backend_addresses=None,
+        )
+        if item.tunnel_interfaces is not None:
+            result['tunnel_interfaces'] = [dict(
+                port=ti.port,
+                identifier=ti.identifier,
+                protocol=ti.protocol,
+                type=ti.type,
+            ) for ti in item.tunnel_interfaces]
+        if item.load_balancer_backend_addresses is not None:
+            result['load_balancer_backend_addresses'] = [dict(
+                name=addr.name,
+                ip_address=addr.ip_address,
+                virtual_network=addr.virtual_network.id if addr.virtual_network is not None else None,
+                subnet=addr.subnet.id if addr.subnet is not None else None,
+                network_interface_ip_configuration=(
+                    addr.network_interface_ip_configuration.id
+                    if addr.network_interface_ip_configuration is not None else None
+                ),
+                load_balancer_frontend_ip_configuration=(
+                    addr.load_balancer_frontend_ip_configuration.id
+                    if addr.load_balancer_frontend_ip_configuration is not None else None
+                ),
+                admin_state=addr.admin_state,
+            ) for addr in item.load_balancer_backend_addresses]
+        return result
+
+
+def main():
+    AzureRMLoadBalancerBackendAddressPool()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
+++ b/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
@@ -18,7 +18,8 @@ short_description: Manage a backend address pool of an Azure load balancer
 
 description:
     - Create, update or delete a single backend address pool on an existing Azure load balancer.
-    - The parent module M(azure.azcollection.azure_rm_loadbalancer) only declares empty pool stubs by name; this module owns all pool-level properties and members.
+    - The parent module M(azure.azcollection.azure_rm_loadbalancer) only declares empty pool stubs by name.
+    - This module owns all pool-level properties and members.
 
 options:
     resource_group:
@@ -162,7 +163,8 @@ EXAMPLES = '''
     name: bepool0
     load_balancer_backend_addresses:
       - name: web-server1-nic
-        network_interface_ip_configuration: /subscriptions/xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/web1-nic/ipConfigurations/ipconfig1
+        network_interface_ip_configuration: >-
+          /subscriptions/xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/web1-nic/ipConfigurations/ipconfig1
 
 - name: Delete backend address pool
   azure_rm_loadbalancerbackendaddresspool:

--- a/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
+++ b/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
@@ -260,10 +260,10 @@ backend_address_spec = dict(
 
 
 tunnel_interface_spec = dict(
-    port=dict(type='int'),
-    identifier=dict(type='int'),
-    protocol=dict(type='str', choices=['None', 'Native', 'VXLAN']),
-    type=dict(type='str', choices=['None', 'Internal', 'External']),
+    port=dict(type='int', required=True),
+    identifier=dict(type='int', required=True),
+    protocol=dict(type='str', choices=['None', 'Native', 'VXLAN'], required=True),
+    type=dict(type='str', choices=['None', 'Internal', 'External'], required=True),
 )
 
 
@@ -278,8 +278,17 @@ class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
             virtual_network=dict(type='str'),
             sync_mode=dict(type='str', choices=['Automatic', 'Manual']),
             drain_period_in_seconds=dict(type='int'),
-            tunnel_interfaces=dict(type='list', elements='dict', options=tunnel_interface_spec),
-            load_balancer_backend_addresses=dict(type='list', elements='dict', options=backend_address_spec),
+            tunnel_interfaces=dict(
+                type='list', elements='dict',
+                options=tunnel_interface_spec,
+            ),
+            load_balancer_backend_addresses=dict(
+                type='list', elements='dict',
+                options=backend_address_spec,
+                mutually_exclusive=[
+                    ('ip_address', 'network_interface_ip_configuration', 'load_balancer_frontend_ip_configuration'),
+                ],
+            ),
         )
 
         self.resource_group = None
@@ -298,6 +307,7 @@ class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
             derived_arg_spec=self.module_arg_spec,
             supports_check_mode=True,
             supports_tags=False,
+            required_by=dict(sync_mode=['virtual_network']),
         )
 
     def exec_module(self, **kwargs):
@@ -306,6 +316,11 @@ class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
 
         existing = self.get_backend_address_pool()
         existing_dict = self.format_item(existing) if existing else None
+        if self.state == 'present' and existing_dict is not None:
+            for field in ('virtual_network', 'sync_mode', 'drain_period_in_seconds',
+                          'tunnel_interfaces', 'load_balancer_backend_addresses'):
+                if getattr(self, field) is None:
+                    setattr(self, field, existing_dict.get(field))
         desired = self.build_desired_dict()
         changed = False
         response = existing_dict
@@ -316,7 +331,9 @@ class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
                 if not self.check_mode:
                     response = self.create_or_update()
             else:
-                if not self.default_compare({}, desired, existing_dict, '', dict(compare=[])):
+                desired_cmp = self._prepare_for_compare(desired)
+                existing_cmp = self._prepare_for_compare(existing_dict)
+                if not self.default_compare({}, desired_cmp, existing_cmp, '', dict(compare=[])):
                     changed = True
                     if not self.check_mode:
                         response = self.create_or_update()
@@ -330,6 +347,23 @@ class AzureRMLoadBalancerBackendAddressPool(AzureRMModuleBaseExt):
         self.results['changed'] = changed
         self.results['state'] = response
         return self.results
+
+    @staticmethod
+    def _prepare_for_compare(pool_dict):
+        '''
+        Prepare the backend address pool dictionary for comparison by sorting
+        the load balancer backend addresses by name.
+
+        :param pool_dict: The backend address pool dictionary.
+        :return: The prepared backend address pool dictionary.
+        '''
+        if pool_dict is None:
+            return None
+        result = dict(pool_dict)
+        addresses = result.get('load_balancer_backend_addresses')
+        if addresses:
+            result['load_balancer_backend_addresses'] = sorted(addresses, key=lambda a: a.get('name') or '')
+        return result
 
     def build_desired_dict(self):
         return dict(

--- a/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
+++ b/plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
@@ -73,14 +73,17 @@ options:
                 description:
                     - Port of the gateway load balancer tunnel interface.
                 type: int
+                required: true
             identifier:
                 description:
                     - Identifier of the gateway load balancer tunnel interface.
                 type: int
+                required: true
             protocol:
                 description:
                     - Protocol of the gateway load balancer tunnel interface.
                 type: str
+                required: true
                 choices:
                     - None
                     - Native
@@ -89,6 +92,7 @@ options:
                 description:
                     - Traffic type of the gateway load balancer tunnel interface.
                 type: str
+                required: true
                 choices:
                     - None
                     - Internal

--- a/plugins/modules/azure_rm_loadbalancerbackendaddresspool_info.py
+++ b/plugins/modules/azure_rm_loadbalancerbackendaddresspool_info.py
@@ -1,0 +1,220 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Zun Yang (@zunyangc).
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_loadbalancerbackendaddresspool_info
+
+version_added: '4.0.0'
+
+short_description: Get facts for one or all backend address pools of an Azure load balancer
+
+description:
+    - Get facts for a single backend address pool by name, or list all backend address pools on a load balancer.
+
+options:
+    resource_group:
+        description:
+            - Name of the resource group that contains the load balancer.
+        required: true
+        type: str
+    load_balancer_name:
+        description:
+            - Name of the parent load balancer.
+        required: true
+        type: str
+    name:
+        description:
+            - Name of a specific backend address pool.
+            - If omitted, all backend address pools on the load balancer are returned.
+        type: str
+
+extends_documentation_fragment:
+    - azure.azcollection.azure
+
+author:
+    - Zun Yang (@zunyangc)
+'''
+
+EXAMPLES = '''
+- name: Get facts for a single backend address pool
+  azure_rm_loadbalancerbackendaddresspool_info:
+    resource_group: myResourceGroup
+    load_balancer_name: myLoadBalancer
+    name: bepool0
+
+- name: List all backend address pools on a load balancer
+  azure_rm_loadbalancerbackendaddresspool_info:
+    resource_group: myResourceGroup
+    load_balancer_name: myLoadBalancer
+'''
+
+RETURN = '''
+backend_address_pools:
+    description:
+        - List of backend address pools matching the query.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        id:
+            description:
+                - Resource ID of the backend address pool.
+            type: str
+            returned: always
+            sample: "/subscriptions/xxx/resourceGroups/myRG/providers/Microsoft.Network/loadBalancers/myLB/backendAddressPools/bepool0"
+        name:
+            description:
+                - Name of the backend address pool.
+            type: str
+            returned: always
+            sample: bepool0
+        provisioning_state:
+            description:
+                - Provisioning state of the backend address pool.
+            type: str
+            returned: always
+            sample: Succeeded
+        virtual_network:
+            description:
+                - Resource ID of the virtual network the pool is bound to.
+            type: str
+            returned: when-used
+            sample: null
+        sync_mode:
+            description:
+                - Backend address synchronous mode.
+            type: str
+            returned: when-used
+            sample: null
+        drain_period_in_seconds:
+            description:
+                - Drain period in seconds.
+            type: int
+            returned: when-used
+            sample: null
+        load_balancer_backend_addresses:
+            description:
+                - List of backend addresses attached to the pool.
+            type: list
+            returned: when-used
+        tunnel_interfaces:
+            description:
+                - Gateway load balancer tunnel interfaces.
+            type: list
+            returned: when-used
+'''
+
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+
+class AzureRMLoadBalancerBackendAddressPoolInfo(AzureRMModuleBase):
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(type='str', required=True),
+            load_balancer_name=dict(type='str', required=True),
+            name=dict(type='str'),
+        )
+
+        self.results = dict(changed=False, backend_address_pools=[])
+        self.resource_group = None
+        self.load_balancer_name = None
+        self.name = None
+
+        super(AzureRMLoadBalancerBackendAddressPoolInfo, self).__init__(
+            self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
+
+    def exec_module(self, **kwargs):
+        for key in list(self.module_arg_spec):
+            setattr(self, key, kwargs[key])
+
+        if self.name:
+            pool = self.get_backend_address_pool()
+            pools = [pool] if pool else []
+        else:
+            pools = self.list_backend_address_pools()
+
+        self.results['backend_address_pools'] = [self.format_item(p) for p in pools]
+        return self.results
+
+    def get_backend_address_pool(self):
+        try:
+            return self.network_client.load_balancer_backend_address_pools.get(
+                self.resource_group, self.load_balancer_name, self.name
+            )
+        except ResourceNotFoundError:
+            return None
+
+    def list_backend_address_pools(self):
+        try:
+            return list(self.network_client.load_balancer_backend_address_pools.list(
+                self.resource_group, self.load_balancer_name
+            ))
+        except ResourceNotFoundError:
+            return []
+        except Exception as exc:
+            self.fail("Error listing backend address pools on load balancer {0} - {1}".format(
+                self.load_balancer_name, str(exc)))
+
+    def format_item(self, item):
+        if item is None:
+            return None
+        result = dict(
+            id=item.id,
+            name=item.name,
+            provisioning_state=item.provisioning_state,
+            virtual_network=item.virtual_network.id if item.virtual_network is not None else None,
+            sync_mode=item.sync_mode,
+            drain_period_in_seconds=item.drain_period_in_seconds,
+            tunnel_interfaces=None,
+            load_balancer_backend_addresses=None,
+        )
+        if item.tunnel_interfaces is not None:
+            result['tunnel_interfaces'] = [dict(
+                port=ti.port,
+                identifier=ti.identifier,
+                protocol=ti.protocol,
+                type=ti.type,
+            ) for ti in item.tunnel_interfaces]
+        if item.load_balancer_backend_addresses is not None:
+            result['load_balancer_backend_addresses'] = [dict(
+                name=addr.name,
+                ip_address=addr.ip_address,
+                virtual_network=addr.virtual_network.id if addr.virtual_network is not None else None,
+                subnet=addr.subnet.id if addr.subnet is not None else None,
+                network_interface_ip_configuration=(
+                    addr.network_interface_ip_configuration.id
+                    if addr.network_interface_ip_configuration is not None else None
+                ),
+                load_balancer_frontend_ip_configuration=(
+                    addr.load_balancer_frontend_ip_configuration.id
+                    if addr.load_balancer_frontend_ip_configuration is not None else None
+                ),
+                admin_state=addr.admin_state,
+            ) for addr in item.load_balancer_backend_addresses]
+        return result
+
+
+def main():
+    AzureRMLoadBalancerBackendAddressPoolInfo()
+
+
+if __name__ == '__main__':
+    main()

--- a/pr-pipelines.yml
+++ b/pr-pipelines.yml
@@ -83,6 +83,7 @@ parameters:
       - "azure_rm_keyvaultsecret"
       - "azure_rm_keyvaultcertificate"
       - "azure_rm_loadbalancer"
+      - "azure_rm_loadbalancerbackendaddresspool"
       - "azure_rm_loganalyticsworkspace"
       - "azure_rm_localnetworkgateway"
       - "azure_rm_manageddisk"

--- a/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/aliases
+++ b/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+shippable/azure/group12
+destructive

--- a/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/meta/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_azure

--- a/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/tasks/main.yml
@@ -140,12 +140,11 @@
           - info_by_name.backend_address_pools[0].id is match('^/subscriptions/.+/backendAddressPools/bepool0$')
           - info_by_name.backend_address_pools[0].provisioning_state == 'Succeeded'
 
-    - name: Set drain_period_in_seconds and admin_state on addr1
+    - name: Set admin_state Down on addr1
       azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
         resource_group: "{{ resource_group }}-lbbepool"
         load_balancer_name: "lb{{ rpfx }}"
         name: bepool0
-        drain_period_in_seconds: 30
         load_balancer_backend_addresses:
           - name: addr1
             ip_address: 10.20.0.10
@@ -156,11 +155,10 @@
             virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
       register: attrs_output
 
-    - name: Assert drain_period and admin_state round-tripped
+    - name: Assert admin_state round-tripped
       ansible.builtin.assert:
         that:
           - attrs_output is changed
-          - attrs_output.state.drain_period_in_seconds == 30
           - (attrs_output.state.load_balancer_backend_addresses | selectattr('name', 'equalto', 'addr1') | list | first).admin_state == 'Down'
 
     - name: Attempt a shrink to one address with check_mode enabled

--- a/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/tasks/main.yml
@@ -1,0 +1,234 @@
+- name: Prepare resource group
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}-lbbepool"
+    location: eastus
+
+- name: Backend address pool child-module test
+  block:
+    - name: Prepare random names
+      ansible.builtin.set_fact:
+        rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      run_once: true
+
+    - name: Create virtual network for pool addresses
+      azure.azcollection.azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}-lbbepool"
+        name: "vn{{ rpfx }}"
+        address_prefixes: "10.20.0.0/16"
+
+    - name: Create subnet
+      azure.azcollection.azure_rm_subnet:
+        resource_group: "{{ resource_group }}-lbbepool"
+        virtual_network: "vn{{ rpfx }}"
+        name: "sn{{ rpfx }}"
+        address_prefix: "10.20.0.0/24"
+
+    - name: Get vnet facts
+      azure.azcollection.azure_rm_virtualnetwork_info:
+        resource_group: "{{ resource_group }}-lbbepool"
+        name: "vn{{ rpfx }}"
+      register: vnet_info
+
+    - name: Create public IP for load balancer
+      azure.azcollection.azure_rm_publicipaddress:
+        resource_group: "{{ resource_group }}-lbbepool"
+        name: "pip{{ rpfx }}"
+        sku: Standard
+        allocation_method: Static
+
+    - name: Create Standard SKU load balancer with an empty pool
+      azure.azcollection.azure_rm_loadbalancer:
+        resource_group: "{{ resource_group }}-lbbepool"
+        name: "lb{{ rpfx }}"
+        sku: Standard
+        frontend_ip_configurations:
+          - name: fe0
+            public_ip_address: "pip{{ rpfx }}"
+        backend_address_pools:
+          - name: bepool0
+
+    - name: Create backend address pool with two IP-based addresses
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        load_balancer_backend_addresses:
+          - name: addr1
+            ip_address: 10.20.0.10
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+          - name: addr2
+            ip_address: 10.20.0.11
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+      register: create_output
+
+    - name: Assert pool created with two addresses
+      ansible.builtin.assert:
+        that:
+          - create_output is changed
+          - create_output.state.name == 'bepool0'
+          - create_output.state.load_balancer_backend_addresses | length == 2
+
+    - name: Re-apply same pool addresses (idempotent)
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        load_balancer_backend_addresses:
+          - name: addr1
+            ip_address: 10.20.0.10
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+          - name: addr2
+            ip_address: 10.20.0.11
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+      register: idem_output
+
+    - name: Assert no change on re-apply
+      ansible.builtin.assert:
+        that:
+          - idem_output is not changed
+
+    - name: Update pool membership (remove addr2, add addr3)
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        load_balancer_backend_addresses:
+          - name: addr1
+            ip_address: 10.20.0.10
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+          - name: addr3
+            ip_address: 10.20.0.12
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+      register: update_output
+
+    - name: Assert membership change detected
+      ansible.builtin.assert:
+        that:
+          - update_output is changed
+          - update_output.state.load_balancer_backend_addresses | length == 2
+          - (update_output.state.load_balancer_backend_addresses | map(attribute='name') | list | sort) == ['addr1', 'addr3']
+
+    - name: Get pool facts by name
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool_info:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+      register: info_by_name
+
+    - name: Assert info returns the pool
+      ansible.builtin.assert:
+        that:
+          - info_by_name.backend_address_pools | length == 1
+          - info_by_name.backend_address_pools[0].name == 'bepool0'
+          - info_by_name.backend_address_pools[0].load_balancer_backend_addresses | length == 2
+
+    - name: List all pools on load balancer
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool_info:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+      register: info_list
+
+    - name: Assert list contains the pool
+      ansible.builtin.assert:
+        that:
+          - info_list.backend_address_pools | length >= 1
+          - "'bepool0' in (info_list.backend_address_pools | map(attribute='name') | list)"
+
+    - name: Assert pool state carries id and provisioning_state
+      ansible.builtin.assert:
+        that:
+          - info_by_name.backend_address_pools[0].id is match('^/subscriptions/.+/backendAddressPools/bepool0$')
+          - info_by_name.backend_address_pools[0].provisioning_state == 'Succeeded'
+
+    - name: Set drain_period_in_seconds and admin_state on addr1
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        drain_period_in_seconds: 30
+        load_balancer_backend_addresses:
+          - name: addr1
+            ip_address: 10.20.0.10
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+            admin_state: Down
+          - name: addr3
+            ip_address: 10.20.0.12
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+      register: attrs_output
+
+    - name: Assert drain_period and admin_state round-tripped
+      ansible.builtin.assert:
+        that:
+          - attrs_output is changed
+          - attrs_output.state.drain_period_in_seconds == 30
+          - (attrs_output.state.load_balancer_backend_addresses | selectattr('name', 'equalto', 'addr1') | list | first).admin_state == 'Down'
+
+    - name: Attempt a shrink to one address with check_mode enabled
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        load_balancer_backend_addresses:
+          - name: addr1
+            ip_address: 10.20.0.10
+            virtual_network: "{{ vnet_info.virtualnetworks[0].id }}"
+      check_mode: true
+      register: checkmode_output
+
+    - name: Read pool state after the check_mode call
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool_info:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+      register: after_checkmode
+
+    - name: Assert check_mode reported changed but did not mutate Azure state
+      ansible.builtin.assert:
+        that:
+          - checkmode_output is changed
+          - after_checkmode.backend_address_pools[0].load_balancer_backend_addresses | length == 2
+
+    - name: Query a non-existent pool via _info
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool_info:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: doesnotexist
+      register: info_missing
+
+    - name: Assert missing pool returns empty list, not error
+      ansible.builtin.assert:
+        that:
+          - info_missing.backend_address_pools | length == 0
+
+    - name: Delete backend address pool
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        state: absent
+      register: delete_output
+
+    - name: Assert pool deleted
+      ansible.builtin.assert:
+        that:
+          - delete_output is changed
+
+    - name: Delete backend address pool (idempotent)
+      azure.azcollection.azure_rm_loadbalancerbackendaddresspool:
+        resource_group: "{{ resource_group }}-lbbepool"
+        load_balancer_name: "lb{{ rpfx }}"
+        name: bepool0
+        state: absent
+      register: delete_output_idem
+
+    - name: Assert no change on second delete
+      ansible.builtin.assert:
+        that:
+          - delete_output_idem is not changed
+
+  always:
+    - name: Force delete the resource group
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ resource_group }}-lbbepool"
+        force_delete_nonempty: true
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Fix #866.
Adds `azure_rm_loadbalancerbackendaddresspool` and `azure_rm_loadbalancerbackendaddresspool_info` modules to manage a load balancer's backend address pool (members, drain period, per-address admin state, VNet binding, tunnel interfaces) as a first-class resource. So users can populate a named pool stub created by `azure_rm_loadbalancer` without re-sending the full LB body.

##### ISSUE TYPE
- [ ] New Feature Pull Request
- [x] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [ ] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_loadbalancerbackendaddresspool.py
- plugins/modules/azure_rm_loadbalancerbackendaddresspool_info.py
- meta/runtime.yml
- tests/integration/targets/azure_rm_loadbalancerbackendaddresspool/

##### ADDITIONAL INFORMATION
- New CRUD module `azure_rm_loadbalancerbackendaddresspool` creates, updates, and deletes a single backend address pool on an existing Azure load balancer via `NetworkManagementClient.load_balancer_backend_address_pools`, avoiding a full-LB PUT on every membership change.
- Pool-level options: `virtual_network`, `sync_mode`, `drain_period_in_seconds`, `tunnel_interfaces`.
- Per-address options in `load_balancer_backend_addresses`: `name`, `ip_address`, `virtual_network`, `subnet`, `network_interface_ip_configuration`, `load_balancer_frontend_ip_configuration`, `admin_state`.
- New info module `azure_rm_loadbalancerbackendaddresspool_info` returns a single pool by name or lists all pools on a load balancer; returns an empty list when the named pool is not found.
- `meta/runtime.yml` registers both modules under `action_groups.azure`.
- Idempotence uses `AzureRMModuleBaseExt.default_compare` on a desired/current dict pair; per-address diffs are order-insensitive by `name`.
- Integration test target `azure_rm_loadbalancerbackendaddresspool` exercises create, idempotence, membership update (add/remove), `admin_state` and `drain_period_in_seconds` round-trip, `check_mode` non-mutation, info by-name, info list-all, info for non-existent pool, delete, and delete idempotence.

##### REFERENCE
- https://learn.microsoft.com/en-us/rest/api/load-balancer/load-balancer-backend-address-pools/create-or-update
- https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/network/azure-mgmt-network (`azure.mgmt.network.models.BackendAddressPool`, `LoadBalancerBackendAddress`, `GatewayLoadBalancerTunnelInterface`)