### PR TITLE
Fix: Address Automation Hub v4.0.0 certification review items

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -93,7 +93,7 @@ jobs:
           testing-type: units
           # OPTIONAL If your unit tests require code
           # from other collections, install them like this
-          #test-deps: >-
+          # test-deps: >-
           #  ansible.netcommon
           #  ansible.utils
           #  vmware.vmware

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible collection for Azure
 [![Doc](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.ansible.com/ansible/latest/collections/azure/azcollection/index.html)
 [![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
-[![License](https://img.shields.io/badge/license-GPL%20v3.0-brightgreen.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-GPL%20v3.0-brightgreen.svg)](https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ## Description
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -66,6 +66,7 @@ issues: https://github.com/ansible-collections/azure/issues
 build_ignore:
   - '*.tar.gz'
   - '*venv*'
+  - '.github'
   - '.vscode'
   - 'ansible_collections'
   - 'ansible.cfg'


### PR DESCRIPTION
##### SUMMARY
Fix the following items:
- .github/workflows/ansible-test.yml: fix yaml[comments] warning by adding missing space after `#` on the `# test-deps` line
- galaxy.yml: add `.github` to build_ignore so GitHub workflow files are excluded from the collection tarball
- README.md: replace relative `LICENSE` link in the badge with the full URL that already appears in the License Information section

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/ansible-test.yml
README.md
galaxy.yml