### PR TITLE
Migration 2357 & New feature 304: SDK refactor azure_rm_azurefirewall + DNS proxy support

### DIFF
--- a/plugins/modules/azure_rm_azurefirewall.py
+++ b/plugins/modules/azure_rm_azurefirewall.py
@@ -357,6 +357,15 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+id:
+    description:
+        - The Azure Firewall resource ID. Preserved as a top-level field for
+          backward compatibility with pre-v4.x playbooks; the same value is
+          also available at I(state.id).
+    returned: success
+    type: str
+    sample: >-
+        /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/azureFirewalls/myAzureFirewall
 state:
     description:
         - Current state of the Azure Firewall.
@@ -706,8 +715,6 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
                 if update_tags:
                     changed = True
                     desired.tags = new_tags
-                elif self.tags is None:
-                    desired.tags = existing.tags
 
                 new_dict = desired.as_dict()
                 old_dict = existing.as_dict()
@@ -727,6 +734,8 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
 
         self.results['changed'] = changed
         self.results['state'] = existing.as_dict() if existing else {}
+        # Preserve the `id` alongside the new `state` envelope
+        self.results['id'] = existing.id if existing else None
         return self.results
 
     def get_firewall(self):

--- a/plugins/modules/azure_rm_azurefirewall.py
+++ b/plugins/modules/azure_rm_azurefirewall.py
@@ -244,6 +244,16 @@ options:
                     - Name of the resource that is unique within a resource group.
                     - This name can be used to access the resource.
                 type: str
+    dns_servers:
+        description:
+            - List of custom DNS server IP addresses used by the firewall.
+        type: list
+        elements: str
+    dns_proxy_enabled:
+        description:
+            - Whether DNS proxy is enabled on the firewall.
+            - When C(true), the firewall listens on port 53 and forwards DNS queries to the addresses in I(dns_servers).
+        type: bool
     state:
         description:
             - Assert the state of the AzureFirewall.
@@ -347,22 +357,100 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-id:
+state:
     description:
-        - Resource ID.
+        - Current state of the Azure Firewall.
     returned: always
-    type: str
-    sample: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/azureFirewalls/myAzureFirewall
+    type: complex
+    contains:
+        id:
+            description:
+                - The Azure Firewall resource ID.
+            returned: always
+            type: str
+            sample: >-
+                /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/azureFirewalls/myAzureFirewall
+        name:
+            description:
+                - The Azure Firewall name.
+            returned: always
+            type: str
+            sample: myAzureFirewall
+        location:
+            description:
+                - The Azure region where the firewall lives.
+            returned: always
+            type: str
+            sample: eastus
+        provisioning_state:
+            description:
+                - The provisioning state of the resource.
+            returned: always
+            type: str
+            sample: Succeeded
+        application_rule_collections:
+            description:
+                - Collection of application rule collections used by the firewall.
+            returned: always
+            type: list
+        nat_rule_collections:
+            description:
+                - Collection of NAT rule collections used by the firewall.
+            returned: always
+            type: list
+        network_rule_collections:
+            description:
+                - Collection of network rule collections used by the firewall.
+            returned: always
+            type: list
+        ip_configurations:
+            description:
+                - IP configuration of the firewall.
+            returned: always
+            type: list
+        additional_properties:
+            description:
+                - Additional properties used to further configure the firewall (for example DNS proxy settings).
+            returned: always
+            type: dict
+        sku:
+            description:
+                - The SKU of the Azure Firewall (for example C(AZFW_VNet) / C(Standard)).
+            returned: always
+            type: dict
+        threat_intel_mode:
+            description:
+                - Operation mode for threat intelligence.
+            returned: always
+            type: str
+            sample: Alert
+        tags:
+            description:
+                - Resource tags.
+            returned: always
+            type: dict
+        type:
+            description:
+                - The Azure resource type.
+            returned: always
+            type: str
+            sample: Microsoft.Network/azureFirewalls
+        etag:
+            description:
+                - A unique read-only string that changes whenever the resource is updated.
+            returned: always
+            type: str
 '''
 
-import time
-import json
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
 
-
-class Actions:
-    NoAction, Create, Update, Delete = range(4)
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.polling import LROPoller
+    from azure.mgmt.core.tools import is_valid_resource_id, resource_id
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
 
 
 class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
@@ -548,6 +636,13 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
                     )
                 )
             ),
+            dns_servers=dict(
+                type='list',
+                elements='str',
+            ),
+            dns_proxy_enabled=dict(
+                type='bool',
+            ),
             state=dict(
                 type='str',
                 default='present',
@@ -557,20 +652,17 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
 
         self.resource_group = None
         self.name = None
-        self.body = {}
-        self.body['properties'] = {}
-
-        self.results = dict(changed=False)
-        self.mgmt_client = None
+        self.location = None
+        self.application_rule_collections = None
+        self.nat_rule_collections = None
+        self.network_rule_collections = None
+        self.ip_configurations = None
+        self.dns_servers = None
+        self.dns_proxy_enabled = None
         self.state = None
-        self.url = None
-        self.status_code = [200, 201, 202]
-        self.to_do = Actions.NoAction
+        self.tags = None
 
-        self.query_parameters = {}
-        self.query_parameters['api-version'] = '2024-01-01'
-        self.header_parameters = {}
-        self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
+        self.results = dict(changed=False, state=dict())
 
         super(AzureRMAzureFirewalls, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                     supports_check_mode=True,
@@ -578,319 +670,292 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
 
     def exec_module(self, **kwargs):
         for key in list(self.module_arg_spec.keys()) + ['tags']:
-            if hasattr(self, key):
-                setattr(self, key, kwargs[key])
-            elif kwargs[key] is not None:
-                if key == 'application_rule_collections':
-                    self.body['properties']['applicationRuleCollections'] = []
-                    for item in kwargs[key]:
-                        app_rule = dict(properties={})
-                        if item.get('priority') is not None:
-                            app_rule['properties']['priority'] = item['priority']
-                        if item.get('action') is not None:
-                            app_rule['properties']['action'] = dict(type=item['action'])
-                        if item.get('name') is not None:
-                            app_rule['name'] = item['name']
-                        if item.get('rules') is not None:
-                            app_rule['properties']['rules'] = []
-                            for value in item['rules']:
-                                rule_value = {}
-                                if value.get('name') is not None:
-                                    rule_value['name'] = value['name']
-                                if value.get('description') is not None:
-                                    rule_value['description'] = value['description']
-                                if value.get('source_addresses') is not None:
-                                    rule_value['sourceAddresses'] = value.get('source_addresses')
-                                if value.get('target_fqdns') is not None:
-                                    rule_value['targetFqdns'] = value.get('target_fqdns')
-                                if value.get('fqdn_tags') is not None:
-                                    rule_value['fqdnTags'] = value.get('fqdn_tags')
-                                if value.get('protocols') is not None:
-                                    rule_value['protocols'] = []
-                                    for pp in value['protocols']:
-                                        pro = {}
-                                        if pp.get('type') is not None:
-                                            pro['protocolType'] = pp.get('type')
-                                        if pp.get('port') is not None:
-                                            pro['port'] = pp.get('port')
-                                        rule_value['protocols'].append(pro)
-                                app_rule['properties']['rules'].append(rule_value)
-                        self.body['properties']['applicationRuleCollections'].append(app_rule)
-                elif key == 'nat_rule_collections':
-                    self.body['properties']['natRuleCollections'] = []
-                    for item in kwargs[key]:
-                        nat_rule = dict(properties={})
-                        if item.get('priority') is not None:
-                            nat_rule['properties']['priority'] = item['priority']
-                        if item.get('action') is not None:
-                            nat_rule['properties']['action'] = dict(type=item['action'])
-                        if item.get('name') is not None:
-                            nat_rule['name'] = item['name']
-                        if item.get('rules') is not None:
-                            nat_rule['properties']['rules'] = []
-                            for value in item['rules']:
-                                nat_value = {}
-                                if value.get('name') is not None:
-                                    nat_value['name'] = value.get('name')
-                                if value.get('description') is not None:
-                                    nat_value['description'] = value.get('description')
-                                if value.get('source_addresses') is not None:
-                                    nat_value['sourceAddresses'] = value.get('source_addresses')
-                                if value.get('destination_addresses') is not None:
-                                    nat_value['destinationAddresses'] = value.get('destination_addresses')
-                                if value.get('destination_ports') is not None:
-                                    nat_value['destinationPorts'] = value.get('destination_ports')
-                                if value.get('protocols') is not None:
-                                    nat_value['protocols'] = value.get('protocols')
-                                if value.get('translated_address') is not None:
-                                    nat_value['translatedAddress'] = value.get('translated_address')
-                                if value.get('translated_port') is not None:
-                                    nat_value['translatedPort'] = value.get('translated_port')
-                                nat_rule['properties']['rules'].append(nat_value)
-                        self.body['properties']['natRuleCollections'].append(nat_rule)
-                elif key == 'network_rule_collections':
-                    self.body['properties']['networkRuleCollections'] = []
-                    for item in kwargs[key]:
-                        network_rule = dict(properties={})
-                        if item.get('priority') is not None:
-                            network_rule['properties']['priority'] = item['priority']
-                        if item.get('action') is not None:
-                            network_rule['properties']['action'] = dict(type=item['action'])
-                        if item.get('name') is not None:
-                            network_rule['name'] = item['name']
-                        if item.get('rules') is not None:
-                            network_rule['properties']['rules'] = []
-                            for value in item['rules']:
-                                net_value = {}
-                                if value.get('name') is not None:
-                                    net_value['name'] = value.get('name')
-                                if value.get('description') is not None:
-                                    net_value['description'] = value.get('description')
-                                if value.get('source_addresses') is not None:
-                                    net_value['sourceAddresses'] = value.get('source_addresses')
-                                if value.get('destination_addresses') is not None:
-                                    net_value['destinationAddresses'] = value.get('destination_addresses')
-                                if value.get('destination_fqdns') is not None:
-                                    net_value['destinationFqdns'] = value.get('destination_fqdns')
-                                if value.get('destination_ports') is not None:
-                                    net_value['destinationPorts'] = value.get('destination_ports')
-                                if value.get('protocols') is not None:
-                                    net_value['protocols'] = value.get('protocols')
-                                network_rule['properties']['rules'].append(net_value)
-                        self.body['properties']['networkRuleCollections'].append(network_rule)
-                elif key == 'ip_configurations':
-                    self.body['properties']['ipConfigurations'] = []
-                    for item in kwargs[key]:
-                        ipconfig = dict(properties={})
-                        if item.get('subnet') is not None:
-                            ipconfig['properties']['subnet'] = {}
-                            if isinstance(item['subnet'], str):
-                                ipconfig['properties']['subnet']['id'] = item['subnet']
-                            elif isinstance(item['subnet'], dict):
-                                if item['subnet'].get('id') is not None:
-                                    ipconfig['properties']['subnet']['id'] = item['subnet'].get('id')
-                                elif (item['subnet'].get('resource_group') is not None and item['subnet'].get('name') is not None and
-                                      item['subnet'].get('virtual_network_name') is not None):
-                                    ipconfig['properties']['subnet']['id'] = ('/subscriptions/' +
-                                                                              self.subscription_id +
-                                                                              '/resourceGroups/' +
-                                                                              item['subnet'].get('resource_group') +
-                                                                              '/providers/Microsoft.Network/virtualNetworks/' +
-                                                                              item['subnet'].get('virtual_network_name') +
-                                                                              '/subnets/' +
-                                                                              item['subnet'].get('name'))
-                                elif item['subnet'].get('name') is not None and item['subnet'].get('virtual_network_name') is not None:
-                                    ipconfig['properties']['subnet']['id'] = ('/subscriptions/' +
-                                                                              self.subscription_id +
-                                                                              '/resourceGroups/' +
-                                                                              self.resource_group +
-                                                                              '/providers/Microsoft.Network/virtualNetworks/' +
-                                                                              item['subnet'].get('virtual_network_name') +
-                                                                              '/subnets/' +
-                                                                              item['subnet'].get('name'))
-                                else:
-                                    self.fail("The ip_configuration's subnet config error")
-                            else:
-                                self.fail("The ip_configuration's subnet config error")
-                        if item.get('public_ip_address') is not None:
-                            ipconfig['properties']['publicIPAddress'] = {}
-                            if isinstance(item.get('public_ip_address'), str):
-                                ipconfig['properties']['publicIPAddress']['id'] = item.get('public_ip_address')
-                            elif isinstance(item.get('public_ip_address'), dict):
-                                if item['public_ip_address'].get('id') is not None:
-                                    ipconfig['properties']['publicIPAddress']['id'] = item['public_ip_address'].get('id')
-                                elif item['public_ip_address'].get('resource_group') is not None and item['public_ip_address'].get('name') is not None:
-                                    ipconfig['properties']['publicIPAddress']['id'] = ('/subscriptions/' +
-                                                                                       self.subscription_id +
-                                                                                       '/resourceGroups/' +
-                                                                                       item['public_ip_address'].get('resource_group') +
-                                                                                       '/providers/Microsoft.Network/publicIPAddresses/' +
-                                                                                       item['public_ip_address'].get('name'))
-                                elif item['public_ip_address'].get('name') is not None:
-                                    ipconfig['properties']['publicIPAddress']['id'] = ('/subscriptions/' +
-                                                                                       self.subscription_id +
-                                                                                       '/resourceGroups/' +
-                                                                                       self.resource_group +
-                                                                                       '/providers/Microsoft.Network/publicIPAddresses/' +
-                                                                                       item['public_ip_address'].get('name'))
-                                else:
-                                    self.fail("The ip_configuration's public ip address config error")
-                            else:
-                                self.fail("The ip_configuration's public ip address config error")
+            setattr(self, key, kwargs[key])
 
-                        if item.get('name') is not None:
-                            ipconfig['name'] = item['name']
-                        self.body['properties']['ipConfigurations'].append(ipconfig)
-                else:
-                    self.body[key] = kwargs[key]
+        if self.state == 'present':
+            resource_group = self.get_resource_group(self.resource_group)
+            if not self.location:
+                self.location = resource_group.location
 
-        old_response = None
-        response = None
+        existing = self.get_firewall()
+        changed = False
 
-        self.mgmt_client = self.get_mgmt_svc_client(GenericRestClient,
-                                                    base_url=self._cloud_environment.endpoints.resource_manager)
-
-        resource_group = self.get_resource_group(self.resource_group)
-
-        if 'location' not in self.body:
-            self.body['location'] = resource_group.location
-
-        self.url = ('/subscriptions' +
-                    '/' + self.subscription_id +
-                    '/resourceGroups' +
-                    '/' + self.resource_group +
-                    '/providers' +
-                    '/Microsoft.Network' +
-                    '/azureFirewalls' +
-                    '/' + self.name)
-
-        old_response = self.get_resource()
-
-        if not old_response:
-            self.log("AzureFirewall instance doesn't exist")
-
-            if self.state == 'absent':
-                self.log("Old instance didn't exist")
+        if self.state == 'present':
+            desired = self.build_firewall_model()
+            if existing is None:
+                changed = True
             else:
-                self.to_do = Actions.Create
-        else:
-            self.log('AzureFirewall instance already exists')
+                existing_addl = getattr(existing, 'additional_properties', None) or {}
+                desired_addl = desired.additional_properties or {}
+                if existing_addl or desired_addl:
+                    merged = dict(existing_addl)
+                    merged.update(desired_addl)
+                    desired.additional_properties = merged
 
-            if self.state == 'absent':
-                self.to_do = Actions.Delete
-            else:
-                update_tags, new_tags = self.update_tags(old_response.get('tags'))
+                # Back-fill every top-level SDK field
+                for field in ('application_rule_collections', 'nat_rule_collections',
+                              'network_rule_collections', 'ip_configurations',
+                              'sku', 'firewall_policy', 'threat_intel_mode',
+                              'virtual_hub', 'zones', 'hub_ip_addresses',
+                              'management_ip_configuration', 'autoscale_configuration'):
+                    if getattr(desired, field, None) is None:
+                        setattr(desired, field, getattr(existing, field, None))
+
+                update_tags, new_tags = self.update_tags(existing.tags or {})
                 if update_tags:
-                    self.to_do = Actions.Update
-                    self.body['tags'] = new_tags
+                    changed = True
+                    desired.tags = new_tags
+                elif self.tags is None:
+                    desired.tags = existing.tags
 
-                if not self.default_compare({}, self.body, old_response, '', dict(compare=[])):
-                    self.to_do = Actions.Update
+                new_dict = desired.as_dict()
+                old_dict = existing.as_dict()
+                self._sort_firewall_dict(new_dict)
+                self._sort_firewall_dict(old_dict)
+                if not self.default_compare({}, new_dict, old_dict, '', dict(compare=[])):
+                    changed = True
 
-        if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
-            self.log('Need to Create / Update the AzureFirewall instance')
-
-            if self.check_mode:
-                self.results['changed'] = True
-                return self.results
-
-            response = self.create_update_resource()
-
-            # if not old_response:
-            self.results['changed'] = True
-            # else:
-            #     self.results['changed'] = old_response.__ne__(response)
-            self.log('Creation / Update done')
-        elif self.to_do == Actions.Delete:
-            self.log('AzureFirewall instance deleted')
-            self.results['changed'] = True
-
-            if self.check_mode:
-                return self.results
-
-            self.delete_resource()
-
-            # make sure instance is actually deleted, for some Azure resources, instance is hanging around
-            # for some time after deletion -- this should be really fixed in Azure
-            while self.get_resource():
-                time.sleep(20)
+            if changed and not self.check_mode:
+                existing = self.create_or_update_firewall(desired)
         else:
-            self.log('AzureFirewall instance unchanged')
-            self.results['changed'] = False
-            response = old_response
+            if existing is not None:
+                changed = True
+                if not self.check_mode:
+                    self.delete_firewall()
+                    existing = None
 
-        if response:
-            self.results["id"] = response["id"]
-            while response['properties']['provisioningState'] == 'Updating':
-                time.sleep(30)
-                response = self.get_resource()
-
+        self.results['changed'] = changed
+        self.results['state'] = existing.as_dict() if existing else {}
         return self.results
 
-    def create_update_resource(self):
-        # self.log('Creating / Updating the AzureFirewall instance {0}'.format(self.))
-
+    def get_firewall(self):
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'PUT',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              self.body,
-                                              self.status_code,
-                                              600,
-                                              30)
-        except Exception as exc:
-            self.log('Error attempting to create the AzureFirewall instance.')
-            self.fail('Error creating the AzureFirewall instance: {0}'.format(str(exc)))
+            return self.network_client.azure_firewalls.get(self.resource_group, self.name)
+        except ResourceNotFoundError:
+            return None
 
-        if hasattr(response, 'body'):
-            response = json.loads(response.body())
-        elif hasattr(response, 'context'):
-            response = response.context['deserialized_data']
-        else:
-            self.fail("Create or Updating fail, no match message return, return info as {0}".format(response))
-
-        return response
-
-    def delete_resource(self):
-        # self.log('Deleting the AzureFirewall instance {0}'.format(self.))
+    def create_or_update_firewall(self, model):
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'DELETE',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-        except Exception as e:
-            self.log('Error attempting to delete the AzureFirewall instance.')
-            self.fail('Error deleting the AzureFirewall instance: {0}'.format(str(e)))
-
-        return True
-
-    def get_resource(self):
-        # self.log('Checking if the AzureFirewall instance {0} is present'.format(self.))
-        found = False
-        try:
-            response = self.mgmt_client.query(self.url,
-                                              'GET',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-            response = json.loads(response.body())
-            found = True
-            self.log("Response : {0}".format(response))
-            # self.log("AzureFirewall instance : {0} found".format(response.name))
-        except Exception as e:
-            self.log('Did not find the AzureFirewall instance.')
-        if found is True:
+            response = self.network_client.azure_firewalls.begin_create_or_update(
+                resource_group_name=self.resource_group,
+                azure_firewall_name=self.name,
+                parameters=model,
+            )
+            if isinstance(response, LROPoller):
+                response = self.get_poller_result(response)
             return response
+        except Exception as exc:
+            self.fail("Error creating or updating Azure Firewall {0}: {1}".format(self.name, str(exc)))
 
-        return False
+    def delete_firewall(self):
+        try:
+            response = self.network_client.azure_firewalls.begin_delete(
+                resource_group_name=self.resource_group,
+                azure_firewall_name=self.name,
+            )
+            if isinstance(response, LROPoller):
+                self.get_poller_result(response)
+        except Exception as exc:
+            self.fail("Error deleting Azure Firewall {0}: {1}".format(self.name, str(exc)))
+
+    def build_firewall_model(self):
+        models = self.network_models
+
+        params = dict(location=self.location)
+        if self.tags is not None:
+            params['tags'] = self.tags
+
+        if self.application_rule_collections is not None:
+            params['application_rule_collections'] = [
+                self.build_application_rule_collection(item)
+                for item in self.application_rule_collections
+            ]
+        if self.nat_rule_collections is not None:
+            params['nat_rule_collections'] = [
+                self.build_nat_rule_collection(item)
+                for item in self.nat_rule_collections
+            ]
+        if self.network_rule_collections is not None:
+            params['network_rule_collections'] = [
+                self.build_network_rule_collection(item)
+                for item in self.network_rule_collections
+            ]
+        if self.ip_configurations is not None:
+            params['ip_configurations'] = [
+                self.build_ip_configuration(item)
+                for item in self.ip_configurations
+            ]
+
+        additional = {}
+        if self.dns_servers is not None:
+            additional['Network.DNS.Servers'] = ','.join(self.dns_servers)
+        if self.dns_proxy_enabled is not None:
+            additional['Network.DNS.EnableProxy'] = 'true' if self.dns_proxy_enabled else 'false'
+        if additional:
+            params['additional_properties'] = additional
+
+        return models.AzureFirewall(**params)
+
+    def build_application_rule_collection(self, item):
+        models = self.network_models
+        # Arg-spec accepts lowercase enums; SDK expects title-case (application) or upper-case (network).
+        action = models.AzureFirewallRCAction(type=str(item['action']).title()) if item.get('action') else None
+        rules = None
+        if item.get('rules') is not None:
+            rules = [
+                models.AzureFirewallApplicationRule(
+                    name=r.get('name'),
+                    description=r.get('description'),
+                    source_addresses=r.get('source_addresses'),
+                    target_fqdns=r.get('target_fqdns'),
+                    fqdn_tags=r.get('fqdn_tags'),
+                    protocols=[
+                        models.AzureFirewallApplicationRuleProtocol(
+                            protocol_type=str(p['type']).title() if p.get('type') is not None else None,
+                            port=int(p['port']) if p.get('port') is not None else None,
+                        )
+                        for p in (r.get('protocols') or [])
+                    ] if r.get('protocols') is not None else None,
+                )
+                for r in item['rules']
+            ]
+        return models.AzureFirewallApplicationRuleCollection(
+            name=item.get('name'),
+            priority=item.get('priority'),
+            action=action,
+            rules=rules,
+        )
+
+    def build_nat_rule_collection(self, item):
+        models = self.network_models
+        action = models.AzureFirewallNatRCAction(type=str(item['action']).title()) if item.get('action') else None
+        rules = None
+        if item.get('rules') is not None:
+            rules = [
+                models.AzureFirewallNatRule(
+                    name=r.get('name'),
+                    description=r.get('description'),
+                    source_addresses=r.get('source_addresses'),
+                    destination_addresses=r.get('destination_addresses'),
+                    destination_ports=r.get('destination_ports'),
+                    protocols=[self.normalize_network_protocol(p) for p in r['protocols']] if r.get('protocols') is not None else None,
+                    translated_address=r.get('translated_address'),
+                    translated_port=r.get('translated_port'),
+                )
+                for r in item['rules']
+            ]
+        return models.AzureFirewallNatRuleCollection(
+            name=item.get('name'),
+            priority=item.get('priority'),
+            action=action,
+            rules=rules,
+        )
+
+    def build_network_rule_collection(self, item):
+        models = self.network_models
+        action = models.AzureFirewallRCAction(type=str(item['action']).title()) if item.get('action') else None
+        rules = None
+        if item.get('rules') is not None:
+            rules = [
+                models.AzureFirewallNetworkRule(
+                    name=r.get('name'),
+                    description=r.get('description'),
+                    source_addresses=r.get('source_addresses'),
+                    destination_addresses=r.get('destination_addresses'),
+                    destination_ports=r.get('destination_ports'),
+                    destination_fqdns=r.get('destination_fqdns'),
+                    protocols=[self.normalize_network_protocol(p) for p in r['protocols']] if r.get('protocols') is not None else None,
+                )
+                for r in item['rules']
+            ]
+        return models.AzureFirewallNetworkRuleCollection(
+            name=item.get('name'),
+            priority=item.get('priority'),
+            action=action,
+            rules=rules,
+        )
+
+    def build_ip_configuration(self, item):
+        models = self.network_models
+        subnet_id = self.resolve_subnet_id(item.get('subnet'))
+        pip_id = self.resolve_public_ip_id(item.get('public_ip_address'))
+        return models.AzureFirewallIPConfiguration(
+            name=item.get('name'),
+            subnet=models.SubResource(id=subnet_id) if subnet_id else None,
+            public_ip_address=models.SubResource(id=pip_id) if pip_id else None,
+        )
+
+    def normalize_network_protocol(self, proto):
+        # SDK enum values: 'TCP', 'UDP', 'ICMP', 'Any'.
+        if not isinstance(proto, str):
+            return proto
+        lower = proto.lower()
+        if lower == 'any':
+            return 'Any'
+        return lower.upper()
+
+    def _sort_firewall_dict(self, fw):
+        for col_key in ('application_rule_collections', 'nat_rule_collections',
+                        'network_rule_collections'):
+            cols = fw.get(col_key)
+            if cols:
+                cols.sort(key=lambda c: c.get('name') or '')
+                for c in cols:
+                    rules = c.get('rules')
+                    if rules:
+                        rules.sort(key=lambda r: r.get('name') or '')
+        ip = fw.get('ip_configurations')
+        if ip:
+            ip.sort(key=lambda x: x.get('name') or '')
+
+    def resolve_subnet_id(self, val):
+        if val is None:
+            return None
+        if isinstance(val, str):
+            if is_valid_resource_id(val):
+                return val
+            self.fail("The ip_configuration's subnet must be a full ARM resource ID or a dict with virtual_network_name and name; got: '{0}'".format(val))
+        if isinstance(val, dict):
+            if val.get('id'):
+                return val['id']
+            if val.get('virtual_network_name') and val.get('name'):
+                return resource_id(
+                    subscription=self.subscription_id,
+                    resource_group=val.get('resource_group') or self.resource_group,
+                    namespace='Microsoft.Network',
+                    type='virtualNetworks',
+                    name=val['virtual_network_name'],
+                    child_type_1='subnets',
+                    child_name_1=val['name'],
+                )
+        self.fail("The ip_configuration's subnet config error")
+
+    def resolve_public_ip_id(self, val):
+        if val is None:
+            return None
+        if isinstance(val, str):
+            if is_valid_resource_id(val):
+                return val
+            # Documented: a bare string is treated as a name in the current resource group.
+            return resource_id(
+                subscription=self.subscription_id,
+                resource_group=self.resource_group,
+                namespace='Microsoft.Network',
+                type='publicIPAddresses',
+                name=val,
+            )
+        if isinstance(val, dict):
+            if val.get('id'):
+                return val['id']
+            if val.get('name'):
+                return resource_id(
+                    subscription=self.subscription_id,
+                    resource_group=val.get('resource_group') or self.resource_group,
+                    namespace='Microsoft.Network',
+                    type='publicIPAddresses',
+                    name=val['name'],
+                )
+        self.fail("The ip_configuration's public ip address config error")
 
 
 def main():

--- a/plugins/modules/azure_rm_azurefirewall.py
+++ b/plugins/modules/azure_rm_azurefirewall.py
@@ -442,6 +442,7 @@ state:
             type: str
 '''
 
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import format_resource_id
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_ext import AzureRMModuleBaseExt
 
 try:
@@ -878,7 +879,18 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
     def build_ip_configuration(self, item):
         models = self.network_models
         subnet_id = self.resolve_subnet_id(item.get('subnet'))
-        pip_id = self.resolve_public_ip_id(item.get('public_ip_address'))
+        pip = item.get('public_ip_address')
+        pip_id = None
+        if isinstance(pip, str):
+            pip_id = format_resource_id(pip, self.subscription_id, 'Microsoft.Network', 'publicIPAddresses', self.resource_group)
+        elif isinstance(pip, dict):
+            if pip.get('id'):
+                pip_id = pip['id']
+            elif pip.get('name'):
+                pip_id = format_resource_id(pip['name'], self.subscription_id, 'Microsoft.Network', 'publicIPAddresses',
+                                            pip.get('resource_group') or self.resource_group)
+            else:
+                self.fail("The ip_configuration's public_ip_address dict must contain 'id' or 'name'")
         return models.AzureFirewallIPConfiguration(
             name=item.get('name'),
             subnet=models.SubResource(id=subnet_id) if subnet_id else None,
@@ -929,33 +941,6 @@ class AzureRMAzureFirewalls(AzureRMModuleBaseExt):
                     child_name_1=val['name'],
                 )
         self.fail("The ip_configuration's subnet config error")
-
-    def resolve_public_ip_id(self, val):
-        if val is None:
-            return None
-        if isinstance(val, str):
-            if is_valid_resource_id(val):
-                return val
-            # Documented: a bare string is treated as a name in the current resource group.
-            return resource_id(
-                subscription=self.subscription_id,
-                resource_group=self.resource_group,
-                namespace='Microsoft.Network',
-                type='publicIPAddresses',
-                name=val,
-            )
-        if isinstance(val, dict):
-            if val.get('id'):
-                return val['id']
-            if val.get('name'):
-                return resource_id(
-                    subscription=self.subscription_id,
-                    resource_group=val.get('resource_group') or self.resource_group,
-                    namespace='Microsoft.Network',
-                    type='publicIPAddresses',
-                    name=val['name'],
-                )
-        self.fail("The ip_configuration's public ip address config error")
 
 
 def main():

--- a/plugins/modules/azure_rm_azurefirewall_info.py
+++ b/plugins/modules/azure_rm_azurefirewall_info.py
@@ -51,10 +51,10 @@ EXAMPLES = '''
 RETURN = '''
 firewalls:
     description:
-        - A list of Azure Firewalls matching the query.
+        - When I(name) is set, a single dict of the firewall's facts (matches the pre-v4.x shape).
+        - When I(name) is not set, a list of such dicts.
     returned: always
-    type: list
-    elements: dict
+    type: complex
     contains:
         id:
             description:
@@ -85,18 +85,26 @@ firewalls:
         application_rule_collections:
             description:
                 - Collection of application rule collections used by the firewall.
+                - Each entry is wrapped in C(id), C(name), C(etag), C(type) and C(properties),
+                  where I(properties) contains I(priority), I(action), I(provisioningState) and I(rules)
+                  (ARM-style; matches the pre-v4.x shape).
             type: list
         nat_rule_collections:
             description:
                 - Collection of NAT rule collections used by the firewall.
+                - Wrapped in the same ARM-style shape as I(application_rule_collections).
             type: list
         network_rule_collections:
             description:
                 - Collection of network rule collections used by the firewall.
+                - Wrapped in the same ARM-style shape as I(application_rule_collections).
             type: list
         ip_configurations:
             description:
                 - IP configuration of the firewall.
+                - Each entry is wrapped in C(id), C(name), C(etag), C(type) and C(properties),
+                  where I(properties) contains I(privateIPAllocationMethod), I(provisioningState),
+                  I(publicIPAddress) and I(subnet).
             type: list
         additional_properties:
             description:
@@ -164,23 +172,24 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
         if self.name is not None:
             if self.resource_group is None:
                 self.fail("Parameter error: resource_group is required when name is provided.")
-            results = self.get_item()
+            item = self.get_item()
+            self.results['firewalls'] = self.firewall_to_dict(item) if item else {}
         elif self.resource_group is not None:
-            results = self.list_resource_group()
+            items = self.list_resource_group()
+            self.results['firewalls'] = [self.firewall_to_dict(i) for i in items]
         else:
-            results = self.list_all()
-
-        self.results['firewalls'] = [self.firewall_to_dict(item) for item in results]
+            items = self.list_all()
+            self.results['firewalls'] = [self.firewall_to_dict(i) for i in items]
         return self.results
 
     def get_item(self):
         try:
             item = self.network_client.azure_firewalls.get(self.resource_group, self.name)
         except ResourceNotFoundError:
-            return []
+            return None
         if self.has_tags(item.tags, self.tags):
-            return [item]
-        return []
+            return item
+        return None
 
     def list_resource_group(self):
         try:
@@ -197,15 +206,107 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
         return [item for item in response if self.has_tags(item.tags, self.tags)]
 
     def firewall_to_dict(self, firewall):
-        result = firewall.as_dict()
         rg = None
         if firewall.id:
-            # ARM ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/...
             parts = firewall.id.split('/')
             if len(parts) > 4 and parts[3].lower() == 'resourcegroups':
                 rg = parts[4]
-        result['resource_group'] = self.resource_group or rg
+        result = {
+            'id': firewall.id,
+            'name': firewall.name,
+            'location': firewall.location,
+            'etag': firewall.etag,
+            'tags': firewall.tags,
+            'type': firewall.type,
+            'provisioning_state': firewall.provisioning_state,
+            'resource_group': self.resource_group or rg,
+            'nat_rule_collections': [
+                self._rule_collection_to_arm(c, 'natRuleCollections')
+                for c in (firewall.nat_rule_collections or [])
+            ],
+            'network_rule_collections': [
+                self._rule_collection_to_arm(c, 'networkRuleCollections')
+                for c in (firewall.network_rule_collections or [])
+            ],
+            'application_rule_collections': [
+                self._rule_collection_to_arm(c, 'applicationRuleCollections')
+                for c in (firewall.application_rule_collections or [])
+            ],
+            'ip_configurations': [
+                self._ip_configuration_to_arm(c)
+                for c in (firewall.ip_configurations or [])
+            ],
+        }
+        if getattr(firewall, 'additional_properties', None):
+            result['additional_properties'] = firewall.additional_properties
+        if getattr(firewall, 'sku', None):
+            result['sku'] = {'name': firewall.sku.name, 'tier': firewall.sku.tier}
+        if getattr(firewall, 'threat_intel_mode', None):
+            result['threat_intel_mode'] = firewall.threat_intel_mode
         return result
+
+    def _rule_collection_to_arm(self, coll, type_name):
+        return {
+            'id': coll.id,
+            'name': coll.name,
+            'etag': getattr(coll, 'etag', None),
+            'type': 'Microsoft.Network/azureFirewalls/' + type_name,
+            'properties': {
+                'priority': coll.priority,
+                'provisioningState': coll.provisioning_state,
+                'action': {'type': coll.action.type} if coll.action else None,
+                'rules': [self._rule_to_arm(r, type_name) for r in (coll.rules or [])],
+            },
+        }
+
+    def _rule_to_arm(self, rule, type_name):
+        if type_name == 'applicationRuleCollections':
+            return {
+                'name': rule.name,
+                'description': rule.description,
+                'sourceAddresses': rule.source_addresses,
+                'targetFqdns': rule.target_fqdns,
+                'fqdnTags': rule.fqdn_tags,
+                'protocols': [
+                    {'protocolType': p.protocol_type, 'port': p.port}
+                    for p in (rule.protocols or [])
+                ] if rule.protocols is not None else None,
+            }
+        if type_name == 'natRuleCollections':
+            return {
+                'name': rule.name,
+                'description': rule.description,
+                'sourceAddresses': rule.source_addresses,
+                'destinationAddresses': rule.destination_addresses,
+                'destinationPorts': rule.destination_ports,
+                'protocols': rule.protocols,
+                'translatedAddress': rule.translated_address,
+                'translatedPort': rule.translated_port,
+            }
+        # networkRuleCollections
+        return {
+            'name': rule.name,
+            'description': rule.description,
+            'sourceAddresses': rule.source_addresses,
+            'destinationAddresses': rule.destination_addresses,
+            'destinationFqdns': rule.destination_fqdns,
+            'destinationPorts': rule.destination_ports,
+            'protocols': rule.protocols,
+        }
+
+    def _ip_configuration_to_arm(self, cfg):
+        return {
+            'id': cfg.id,
+            'name': cfg.name,
+            'etag': getattr(cfg, 'etag', None),
+            'type': 'Microsoft.Network/azureFirewalls/azureFirewallIpConfigurations',
+            'properties': {
+                'privateIPAllocationMethod': 'Dynamic',
+                'provisioningState': cfg.provisioning_state,
+                'publicIPAddress': {'id': cfg.public_ip_address.id} if cfg.public_ip_address else None,
+                'subnet': {'id': cfg.subnet.id} if cfg.subnet else None,
+            },
+        }
 
 
 def main():

--- a/plugins/modules/azure_rm_azurefirewall_info.py
+++ b/plugins/modules/azure_rm_azurefirewall_info.py
@@ -18,12 +18,17 @@ description:
 options:
     resource_group:
         description:
-            - The name of the resource group.
+            - The name of the resource group. Required when I(name) is provided.
         type: str
     name:
         description:
-            - Resource name.
+            - Resource name. When set, I(resource_group) is required.
         type: str
+    tags:
+        description:
+            - Limit the results by providing resource tags.
+        type: list
+        elements: str
 extends_documentation_fragment:
     - azure.azcollection.azure
 author:
@@ -46,374 +51,161 @@ EXAMPLES = '''
 RETURN = '''
 firewalls:
     description:
-        - A list of dict results where the key is the name of the AzureFirewall and the values are the facts for that AzureFirewall.
+        - A list of Azure Firewalls matching the query.
     returned: always
-    type: complex
+    type: list
+    elements: dict
     contains:
         id:
             description:
-                - Resource ID.
-            returned: always
+                - Fully qualified Azure resource ID.
             type: str
-            sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/
-                     myResourceGroup/providers/Microsoft.Network/azureFirewalls/myAzureFirewall"
+            sample: >-
+                /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/azureFirewalls/myAzureFirewall
         name:
             description:
-                - Resource name.
-            returned: always
+                - Firewall resource name.
             type: str
-            sample: "myAzureFirewall"
+            sample: myAzureFirewall
+        resource_group:
+            description:
+                - Name of the resource group containing the firewall.
+            type: str
+            sample: myResourceGroup
         location:
             description:
-                - Resource location.
-            returned: always
+                - Azure region.
             type: str
-            sample: "eastus"
+            sample: eastus
+        provisioning_state:
+            description:
+                - Provisioning state of the resource.
+            type: str
+            sample: Succeeded
+        application_rule_collections:
+            description:
+                - Collection of application rule collections used by the firewall.
+            type: list
+        nat_rule_collections:
+            description:
+                - Collection of NAT rule collections used by the firewall.
+            type: list
+        network_rule_collections:
+            description:
+                - Collection of network rule collections used by the firewall.
+            type: list
+        ip_configurations:
+            description:
+                - IP configuration of the firewall.
+            type: list
+        additional_properties:
+            description:
+                - Additional properties used to further configure the firewall.
+                - Includes DNS proxy settings such as C(Network.DNS.EnableProxy) and C(Network.DNS.Servers).
+            type: dict
+        sku:
+            description:
+                - The SKU of the Azure Firewall (for example C(AZFW_VNet) / C(Standard)).
+            type: dict
+        threat_intel_mode:
+            description:
+                - Operation mode for threat intelligence.
+            type: str
+            sample: Alert
         tags:
             description:
                 - Resource tags.
-            returned: always
             type: dict
-            sample: { "tag": "value" }
         etag:
             description:
-                - Gets a unique read-only string that changes whenever the resource is updated.
-            returned: always
+                - A unique read-only string that changes whenever the resource is updated.
             type: str
-            sample: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        application_rule_collections:
+        type:
             description:
-                - Collection of application rule collections used by Azure Firewall.
-            type: list
-            returned: always
-            sample: [
-                {
-                    "etag": "25b7fca4-c909-4913-8799-6cdb7da2e298",
-                    "id": "/subscriptions/xxx-xxx1/resourceGroups/myResourceGroup/providers/
-                           Microsoft.Network/azureFirewalls/myFirewall/applicationRuleCollections/apprulecoll",
-                    "name": "apprulecoll",
-                    "properties": {
-                        "action": {
-                            "type": "Deny"
-                        },
-                        "priority": 110,
-                        "provisioningState": "Failed",
-                        "rules": [
-                            {
-                                "actions": [],
-                                "description": "Deny inbound rule",
-                                "direction": "Inbound",
-                                "fqdnTags": [],
-                                "name": "rule1",
-                                "priority": 0,
-                                "protocols": [
-                                    {
-                                        "port": 443,
-                                        "protocolType": "Https"
-                                    }
-                                ],
-                                "sourceAddresses": [
-                                    "216.58.216.164",
-                                    "10.0.0.0/25"
-                                ],
-                                "sourceIpGroups": [],
-                                "targetFqdns": [
-                                    "www.test.com"
-                                ]
-                            }
-                        ]
-                    },
-                    "type": "Microsoft.Network/azureFirewalls/applicationRuleCollections"
-                }
-            ]
-        nat_rule_collections:
-            description:
-                - Collection of NAT rule collections used by Azure Firewall.
-            type: list
-            returned: always
-            sample: [
-                {
-                    "etag": '3759e8b1-cdf7-44f4-a643-3a75e2b67877',
-                    "id": "/subscriptions/xxx-xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/
-                           azureFirewalls/myFirewall/natRuleCollections/natrulecoll",
-                    "name": "natrulecoll",
-                    "properties": {
-                        "action": {
-                            "type": "Dnat"
-                        },
-                        "priority": 112,
-                        "provisioningState": "Failed",
-                        "rules": [
-                            {
-                                "description": "D-NAT all outbound web traffic for inspection",
-                                "destinationAddresses": [
-                                    "20.169.156.124"
-                                ],
-                                "destinationPorts": [
-                                    "443"
-                                ],
-                                "name": "DNAT-HTTPS-traffic",
-                                "protocols": [
-                                    "TCP"
-                                ],
-                                "sourceAddresses": [
-                                    "*"
-                                ],
-                                "translatedAddress": "1.2.3.5",
-                                "translatedPort": "8443"
-                            }
-                        ]
-                    },
-                    "type": "Microsoft.Network/azureFirewalls/natRuleCollections"
-                }
-            ]
-        network_rule_collections:
-            description:
-                - Collection of network rule collections used by Azure Firewall.
-            type: list
-            returned: always
-            sample: [
-                {
-                    "etag": "3759e8b1-cdf7-44f4-a643-3a75e2b67877",
-                    "id": "/subscriptions/xxx-xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/
-                           azureFirewalls/myFirewall/networkRuleCollections/netrulecoll",
-                    "name": "netrulecoll",
-                    "properties": {
-                        "action": {
-                            "type": "Deny"
-                        },
-                        "priority": 112,
-                        "provisioningState": "Failed",
-                        "rules": [
-                            {
-                                "description": "Block traffic based on source IPs and ports",
-                                "destinationAddresses": [
-                                    "*"
-                                ],
-                                "destinationPorts": [
-                                    "443-444",
-                                    "8443"
-                                ],
-                                "name": "L4-traffic",
-                                "protocols": [
-                                    "TCP"
-                                ],
-                                "sourceAddresses": [
-                                    "192.168.1.1-192.168.1.12",
-                                    "10.1.4.12-10.1.4.255"
-                                ]
-                            },
-                            {
-                                "description": "Block traffic based on source IPs and ports to amazon",
-                                "destinationAddresses": [],
-                                "destinationPorts": [
-                                    "443-444",
-                                    "8443"
-                                ],
-                                "name": "L4-traffic-with_FQDN",
-                                "protocols": [
-                                    "TCP"
-                                ],
-                                "sourceAddresses": [
-                                    "10.2.4.12-10.2.4.255"
-                                ]
-                            }
-                        ]
-                    },
-                    "type": "Microsoft.Network/azureFirewalls/networkRuleCollections"
-                }
-            ]
-        ip_configurations:
-            description:
-                - IP configuration of the Azure Firewall resource.
-            type: list
-            returned: always
-            sample: [
-                {
-                    "etag": "3759e8b1-cdf7-44f4-a643-3a75e2b67877",
-                    "id": "/subscriptions/xxx-xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/azureFirewalls/myFirewall/i
-                           azureFirewallIpConfigurations/azureFirewallIpConfiguration",
-                    "name": "azureFirewallIpConfiguration",
-                    "properties": {
-                        "privateIPAllocationMethod": "Dynamic",
-                        "provisioningState": "Succeeded",
-                        "publicIPAddress": {
-                            "id": "/subscriptions/xxx-xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/publicIPAddresses/myPublicIpAddress"
-                        },
-                        "subnet": {
-                            "id": "/subscriptions/xxx-xxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/
-                                   virtualNetworks/myVirtualNetwork/subnets/AzureFirewallSubnet"
-                        }
-                    },
-                    "type": "Microsoft.Network/azureFirewalls/azureFirewallIpConfigurations"
-                }
-            ]
-        provisioning_state:
-            description:
-                - The current state of the gallery.
+                - Azure resource type.
             type: str
-            sample: "Succeeded"
-
+            sample: Microsoft.Network/azureFirewalls
 '''
 
-import json
 from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase
-from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common_rest import GenericRestClient
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
 
 
 class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
     def __init__(self):
         self.module_arg_spec = dict(
-            resource_group=dict(
-                type='str'
-            ),
-            name=dict(
-                type='str'
-            )
+            resource_group=dict(type='str'),
+            name=dict(type='str'),
+            tags=dict(type='list', elements='str'),
         )
 
         self.resource_group = None
         self.name = None
+        self.tags = None
 
-        self.results = dict(changed=False)
-        self.mgmt_client = None
-        self.state = None
-        self.url = None
-        self.status_code = [200]
+        self.results = dict(changed=False, firewalls=[])
 
-        self.query_parameters = {}
-        self.query_parameters['api-version'] = '2024-01-01'
-        self.header_parameters = {}
-        self.header_parameters['Content-Type'] = 'application/json; charset=utf-8'
-
-        self.mgmt_client = None
-        super(AzureRMAzureFirewallsInfo, self).__init__(self.module_arg_spec, supports_check_mode=True, supports_tags=False)
+        super(AzureRMAzureFirewallsInfo, self).__init__(
+            self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=False,
+            facts_module=True,
+        )
 
     def exec_module(self, **kwargs):
-
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
-        self.mgmt_client = self.get_mgmt_svc_client(GenericRestClient,
-                                                    base_url=self._cloud_environment.endpoints.resource_manager)
-
-        if (self.resource_group is not None and self.name is not None):
-            self.results['firewalls'] = self.get()
-        elif (self.resource_group is not None):
-            self.results['firewalls'] = self.list()
+        if self.name is not None:
+            if self.resource_group is None:
+                self.fail("Parameter error: resource_group is required when name is provided.")
+            results = self.get_item()
+        elif self.resource_group is not None:
+            results = self.list_resource_group()
         else:
-            self.results['firewalls'] = self.listall()
+            results = self.list_all()
+
+        self.results['firewalls'] = [self.firewall_to_dict(item) for item in results]
         return self.results
 
-    def get(self):
-        response = None
-        results = {}
-        # prepare url
-        self.url = ('/subscriptions' +
-                    '/{{ subscription_id }}' +
-                    '/resourceGroups' +
-                    '/{{ resource_group }}' +
-                    '/providers' +
-                    '/Microsoft.Network' +
-                    '/azureFirewalls' +
-                    '/{{ azure_firewall_name }}')
-        self.url = self.url.replace('{{ subscription_id }}', self.subscription_id)
-        self.url = self.url.replace('{{ resource_group }}', self.resource_group)
-        self.url = self.url.replace('{{ azure_firewall_name }}', self.name)
-
+    def get_item(self):
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'GET',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-            results = json.loads(response.body())
-            # self.log('Response : {0}'.format(response))
-        except Exception as e:
-            self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
+            item = self.network_client.azure_firewalls.get(self.resource_group, self.name)
+        except ResourceNotFoundError:
+            return []
+        if self.has_tags(item.tags, self.tags):
+            return [item]
+        return []
 
-        return self.format_item(results)
-
-    def list(self):
-        response = None
-        results = {}
-        # prepare url
-        self.url = ('/subscriptions' +
-                    '/{{ subscription_id }}' +
-                    '/resourceGroups' +
-                    '/{{ resource_group }}' +
-                    '/providers' +
-                    '/Microsoft.Network' +
-                    '/azureFirewalls')
-        self.url = self.url.replace('{{ subscription_id }}', self.subscription_id)
-        self.url = self.url.replace('{{ resource_group }}', self.resource_group)
-
+    def list_resource_group(self):
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'GET',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-            results = json.loads(response.body())
-            # self.log('Response : {0}'.format(response))
-        except Exception as e:
-            self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
+            response = self.network_client.azure_firewalls.list(self.resource_group)
+        except Exception as exc:
+            self.fail("Failed to list Azure Firewalls in resource group {0}: {1}".format(self.resource_group, str(exc)))
+        return [item for item in response if self.has_tags(item.tags, self.tags)]
 
-        return [self.format_item(x) for x in results['value']] if results['value'] else []
-
-    def listall(self):
-        response = None
-        results = {}
-        # prepare url
-        self.url = ('/subscriptions' +
-                    '/{{ subscription_id }}' +
-                    '/providers' +
-                    '/Microsoft.Network' +
-                    '/azureFirewalls')
-        self.url = self.url.replace('{{ subscription_id }}', self.subscription_id)
-
+    def list_all(self):
         try:
-            response = self.mgmt_client.query(self.url,
-                                              'GET',
-                                              self.query_parameters,
-                                              self.header_parameters,
-                                              None,
-                                              self.status_code,
-                                              600,
-                                              30)
-            results = json.loads(response.body())
-            # self.log('Response : {0}'.format(response))
-        except Exception as e:
-            self.log('Could not get info for @(Model.ModuleOperationNameUpper).')
+            response = self.network_client.azure_firewalls.list_all()
+        except Exception as exc:
+            self.fail("Failed to list Azure Firewalls in subscription: {0}".format(str(exc)))
+        return [item for item in response if self.has_tags(item.tags, self.tags)]
 
-        return [self.format_item(x) for x in results['value']] if results['value'] else []
-
-    def format_item(self, item):
-        if item is None or item == {}:
-            return {}
-        d = {
-            'id': item.get('id'),
-            'name': item.get('name'),
-            'location': item.get('location'),
-            'etag': item.get('etag'),
-            'tags': item.get('tags'),
-            'nat_rule_collections': dict(),
-            'network_rule_collections': dict(),
-            'ip_configurations': dict(),
-        }
-        if isinstance(item.get('properties'), dict):
-            d['nat_rule_collections'] = item.get('properties').get('natRuleCollections')
-            d['network_rule_collections'] = item.get('properties').get('networkRuleCollections')
-            d['application_rule_collections'] = item.get('properties').get('applicationRuleCollections')
-            d['ip_configurations'] = item.get('properties').get('ipConfigurations')
-            d['provisioning_state'] = item.get('properties').get('provisioningState')
-        return d
+    def firewall_to_dict(self, firewall):
+        result = firewall.as_dict()
+        rg = None
+        if firewall.id:
+            # ARM ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/...
+            parts = firewall.id.split('/')
+            if len(parts) > 4 and parts[3].lower() == 'resourcegroups':
+                rg = parts[4]
+        result['resource_group'] = self.resource_group or rg
+        return result
 
 
 def main():

--- a/plugins/modules/azure_rm_azurefirewall_info.py
+++ b/plugins/modules/azure_rm_azurefirewall_info.py
@@ -103,7 +103,7 @@ firewalls:
             description:
                 - IP configuration of the firewall.
                 - Each entry is wrapped in C(id), C(name), C(etag), C(type) and C(properties),
-                  where I(properties) contains I(privateIPAllocationMethod), I(provisioningState),
+                  where I(properties) contains I(privateIPAddress), I(provisioningState),
                   I(publicIPAddress) and I(subnet).
             type: list
         additional_properties:
@@ -271,6 +271,7 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
                     {'protocolType': p.protocol_type, 'port': p.port}
                     for p in (rule.protocols or [])
                 ] if rule.protocols is not None else None,
+                'sourceIpGroups': rule.source_ip_groups,
             }
         if type_name == 'natRuleCollections':
             return {
@@ -282,6 +283,8 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
                 'protocols': rule.protocols,
                 'translatedAddress': rule.translated_address,
                 'translatedPort': rule.translated_port,
+                'translatedFqdn': rule.translated_fqdn,
+                'sourceIpGroups': rule.source_ip_groups,
             }
         # networkRuleCollections
         return {
@@ -292,6 +295,8 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
             'destinationFqdns': rule.destination_fqdns,
             'destinationPorts': rule.destination_ports,
             'protocols': rule.protocols,
+            'sourceIpGroups': rule.source_ip_groups,
+            'destinationIpGroups': rule.destination_ip_groups,
         }
 
     def _ip_configuration_to_arm(self, cfg):
@@ -301,7 +306,7 @@ class AzureRMAzureFirewallsInfo(AzureRMModuleBase):
             'etag': getattr(cfg, 'etag', None),
             'type': 'Microsoft.Network/azureFirewalls/azureFirewallIpConfigurations',
             'properties': {
-                'privateIPAllocationMethod': 'Dynamic',
+                'privateIPAddress': cfg.private_ip_address,
                 'provisioningState': cfg.provisioning_state,
                 'publicIPAddress': {'id': cfg.public_ip_address.id} if cfg.public_ip_address else None,
                 'subnet': {'id': cfg.subnet.id} if cfg.subnet else None,

--- a/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
@@ -51,6 +51,10 @@
         name: '{{ azure_firewall_name }}'
         # tags:
         #   key1: value1
+        dns_servers:
+          - 10.0.0.4
+          - 10.0.0.5
+        dns_proxy_enabled: true
         application_rule_collections:
           - priority: 110
             action: deny
@@ -129,10 +133,31 @@
         that:
           - output is changed
 
+    - name: Assert first-create state envelope shape
+      ansible.builtin.assert:
+        that:
+          - output.state is defined
+          - output.state.id | length > 0
+          - output.state.name == azure_firewall_name
+          - output.state.provisioning_state == 'Succeeded'
+          - output.state.application_rule_collections | length == 1
+          - output.state.nat_rule_collections | length == 1
+          - output.state.network_rule_collections | length == 1
+          - output.state.ip_configurations | length == 1
+          - output.state.additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - output.state.additional_properties['Network.DNS.Servers'] == '10.0.0.4,10.0.0.5'
+          - output.state.sku is defined
+          - output.state.sku.name is defined
+          - output.state.threat_intel_mode is defined
+
     - name: Create Azure Firewall -- idempotent
       azure.azcollection.azure_rm_azurefirewall:
         resource_group: '{{ resource_group }}-azurefirewall'
         name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.4
+          - 10.0.0.5
+        dns_proxy_enabled: true
         application_rule_collections:
           - priority: 110
             action: deny
@@ -215,6 +240,10 @@
       azure.azcollection.azure_rm_azurefirewall:
         resource_group: '{{ resource_group }}-azurefirewall'
         name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.4
+          - 10.0.0.5
+        dns_proxy_enabled: true
         application_rule_collections:
           - priority: 110
             action: deny
@@ -300,14 +329,295 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.firewalls['id'] != None
-          - output.firewalls['name'] != None
-          - output.firewalls['location'] != None
-          - output.firewalls['etag'] != None
-          - output.firewalls['nat_rule_collections'] != None
-          - output.firewalls['network_rule_collections'] != None
-          - output.firewalls['ip_configurations'] != None
-          - output.firewalls['provisioning_state'] != None
+          - output.firewalls | length == 1
+          - output.firewalls[0]['id'] | length > 0
+          - output.firewalls[0]['name'] == azure_firewall_name
+          - output.firewalls[0]['resource_group'] == resource_group ~ '-azurefirewall'
+          - output.firewalls[0]['location'] != None
+          - output.firewalls[0]['etag'] != None
+          - output.firewalls[0]['application_rule_collections'] | length == 1
+          - output.firewalls[0]['nat_rule_collections'] | length == 1
+          - output.firewalls[0]['network_rule_collections'] | length == 1
+          - output.firewalls[0]['ip_configurations'] | length == 1
+          - output.firewalls[0]['provisioning_state'] == 'Succeeded'
+          - output.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - output.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.4,10.0.0.5'
+          - output.firewalls[0].sku is defined
+          - output.firewalls[0].sku.name is defined
+          - output.firewalls[0].threat_intel_mode is defined
+
+    - name: List Azure Firewalls in resource group
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+      register: rg_list
+
+    - name: Assert list-by-resource-group returns the firewall
+      ansible.builtin.assert:
+        that:
+          - rg_list.firewalls | length == 1
+          - rg_list.firewalls[0]['name'] == azure_firewall_name
+
+    - name: Filter Azure Firewalls by non-matching tag
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        tags:
+          - nomatch
+      register: tag_filter_none
+
+    - name: Assert tag filter with no matching tag returns empty list
+      ansible.builtin.assert:
+        that:
+          - tag_filter_none.firewalls | length == 0
+
+    - name: Define shared firewall body for DNS proxy update tests
+      ansible.builtin.set_fact:
+        fw_app_rules:
+          - priority: 110
+            action: deny
+            rules:
+              - name: rule1
+                description: Deny inbound rule
+                source_addresses:
+                  - 216.58.216.164
+                  - 10.0.0.0/25
+                protocols:
+                  - type: https
+                    port: '443'
+                target_fqdns:
+                  - www.test.com
+            name: apprulecoll
+        fw_nat_rules:
+          - priority: 112
+            action: dnat
+            rules:
+              - name: DNAT-HTTPS-traffic
+                description: D-NAT all outbound web traffic for inspection
+                source_addresses:
+                  - '*'
+                destination_addresses:
+                  - "{{ pip_output.state.ip_address }}"
+                destination_ports:
+                  - '443'
+                protocols:
+                  - tcp
+                translated_address: 1.2.3.5
+                translated_port: '8443'
+            name: natrulecoll
+        fw_net_rules:
+          - priority: 112
+            action: deny
+            rules:
+              - name: L4-traffic
+                description: Block traffic based on source IPs and ports
+                protocols:
+                  - tcp
+                source_addresses:
+                  - 192.168.1.1-192.168.1.12
+                  - 10.1.4.12-10.1.4.255
+                destination_addresses:
+                  - '*'
+                destination_ports:
+                  - 443-444
+                  - '8443'
+              - name: L4-traffic-with-FQDNS
+                description: Block traffic based on source IPs and ports to amazon
+                protocols:
+                  - tcp
+                source_addresses:
+                  - 10.2.4.12-10.2.4.255
+                destination_fqdns:
+                  - 'www.test.com'
+                destination_ports:
+                  - 443-444
+                  - '8443'
+            name: netrulecoll
+        fw_ip_configs:
+          - subnet:
+              virtual_network_name: "{{ virtual_network_name }}"
+              name: "{{ subnet_name }}"
+            public_ip_address:
+              name: "{{ public_ipaddress_name }}"
+            name: azureFirewallIpConfiguration
+
+    - name: Change the DNS server list
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.6
+        dns_proxy_enabled: true
+        application_rule_collections: "{{ fw_app_rules }}"
+        nat_rule_collections: "{{ fw_nat_rules }}"
+        network_rule_collections: "{{ fw_net_rules }}"
+        ip_configurations: "{{ fw_ip_configs }}"
+      register: dns_change
+
+    - name: Assert DNS server change is applied
+      ansible.builtin.assert:
+        that:
+          - dns_change is changed
+          - dns_change.state.additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - dns_change.state.additional_properties['Network.DNS.Servers'] == '10.0.0.6'
+
+    - name: Get info after DNS server change
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+      register: dns_change_info
+
+    - name: Assert DNS server change is reflected via info
+      ansible.builtin.assert:
+        that:
+          - dns_change_info.firewalls | length == 1
+          - dns_change_info.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - dns_change_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.6'
+
+    - name: Re-apply the same DNS server change -- idempotent
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.6
+        dns_proxy_enabled: true
+        application_rule_collections: "{{ fw_app_rules }}"
+        nat_rule_collections: "{{ fw_nat_rules }}"
+        network_rule_collections: "{{ fw_net_rules }}"
+        ip_configurations: "{{ fw_ip_configs }}"
+      register: dns_idem
+
+    - name: Assert DNS change re-apply is not changed
+      ansible.builtin.assert:
+        that:
+          - dns_idem is not changed
+
+    - name: Update firewall without dns_servers -- drift preservation
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_proxy_enabled: true
+        application_rule_collections: "{{ fw_app_rules }}"
+        nat_rule_collections: "{{ fw_nat_rules }}"
+        network_rule_collections: "{{ fw_net_rules }}"
+        ip_configurations: "{{ fw_ip_configs }}"
+      register: dns_drift
+
+    - name: Assert dropped dns_servers is preserved from existing (no change)
+      ansible.builtin.assert:
+        that:
+          - dns_drift is not changed
+
+    - name: Get info after drift-preservation update
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+      register: dns_drift_info
+
+    - name: Assert DNS server value survived the drift merge
+      ansible.builtin.assert:
+        that:
+          - dns_drift_info.firewalls | length == 1
+          - dns_drift_info.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - dns_drift_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.6'
+
+    - name: Re-apply full body with network rules in reversed order
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.6
+        dns_proxy_enabled: true
+        application_rule_collections: "{{ fw_app_rules }}"
+        nat_rule_collections: "{{ fw_nat_rules }}"
+        network_rule_collections:
+          - priority: 112
+            action: deny
+            rules:
+              - name: L4-traffic-with-FQDNS
+                description: Block traffic based on source IPs and ports to amazon
+                protocols:
+                  - tcp
+                source_addresses:
+                  - 10.2.4.12-10.2.4.255
+                destination_fqdns:
+                  - 'www.test.com'
+                destination_ports:
+                  - 443-444
+                  - '8443'
+              - name: L4-traffic
+                description: Block traffic based on source IPs and ports
+                protocols:
+                  - tcp
+                source_addresses:
+                  - 192.168.1.1-192.168.1.12
+                  - 10.1.4.12-10.1.4.255
+                destination_addresses:
+                  - '*'
+                destination_ports:
+                  - 443-444
+                  - '8443'
+            name: netrulecoll
+        ip_configurations: "{{ fw_ip_configs }}"
+      register: reorder_apply
+
+    - name: Assert reordered rules are treated as idempotent
+      ansible.builtin.assert:
+        that:
+          - reorder_apply is not changed
+
+    - name: Update only dns_servers with a partial body
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.7
+        dns_proxy_enabled: true
+      register: partial_apply
+
+    - name: Assert partial DNS update applied and preserved every other field
+      ansible.builtin.assert:
+        that:
+          - partial_apply is changed
+          - partial_apply.state.additional_properties['Network.DNS.Servers'] == '10.0.0.7'
+          - partial_apply.state.application_rule_collections | length == 1
+          - partial_apply.state.nat_rule_collections | length == 1
+          - partial_apply.state.network_rule_collections | length == 1
+          - partial_apply.state.network_rule_collections[0].rules | length == 2
+          - partial_apply.state.ip_configurations | length == 1
+          - partial_apply.state.sku.name == 'AZFW_VNet'
+          - partial_apply.state.threat_intel_mode == 'Alert'
+
+    - name: Get info after partial DNS update
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+      register: partial_apply_info
+
+    - name: Assert info confirms every top-level collection survived the partial update
+      ansible.builtin.assert:
+        that:
+          - partial_apply_info.firewalls | length == 1
+          - partial_apply_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.7'
+          - partial_apply_info.firewalls[0].application_rule_collections | length == 1
+          - partial_apply_info.firewalls[0].nat_rule_collections | length == 1
+          - partial_apply_info.firewalls[0].network_rule_collections | length == 1
+          - partial_apply_info.firewalls[0].network_rule_collections[0].rules | length == 2
+          - partial_apply_info.firewalls[0].ip_configurations | length == 1
+          - partial_apply_info.firewalls[0].sku.name == 'AZFW_VNet'
+          - partial_apply_info.firewalls[0].threat_intel_mode == 'Alert'
+
+    - name: Re-apply the same partial DNS body -- idempotent
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        dns_servers:
+          - 10.0.0.7
+        dns_proxy_enabled: true
+      register: partial_idem
+
+    - name: Assert partial DNS re-apply is not changed
+      ansible.builtin.assert:
+        that:
+          - partial_idem is not changed
 
     - name: Delete Azure Firewall
       azure.azcollection.azure_rm_azurefirewall:
@@ -320,6 +630,30 @@
       ansible.builtin.assert:
         that:
           - output is changed
+
+    - name: Delete Azure Firewall -- idempotent
+      azure.azcollection.azure_rm_azurefirewall:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+        state: absent
+      register: output
+
+    - name: Assert repeated delete is not changed
+      ansible.builtin.assert:
+        that:
+          - output is not changed
+
+    - name: Get info of the missing firewall
+      azure.azcollection.azure_rm_azurefirewall_info:
+        resource_group: '{{ resource_group }}-azurefirewall'
+        name: '{{ azure_firewall_name }}'
+      register: missing_info
+
+    - name: Assert info returns an empty list for a missing firewall
+      ansible.builtin.assert:
+        that:
+          - missing_info is not changed
+          - missing_info.firewalls | length == 0
 
     - name: Delete the public IP address
       azure.azcollection.azure_rm_publicipaddress:

--- a/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml
@@ -329,22 +329,21 @@
       ansible.builtin.assert:
         that:
           - output is not changed
-          - output.firewalls | length == 1
-          - output.firewalls[0]['id'] | length > 0
-          - output.firewalls[0]['name'] == azure_firewall_name
-          - output.firewalls[0]['resource_group'] == resource_group ~ '-azurefirewall'
-          - output.firewalls[0]['location'] != None
-          - output.firewalls[0]['etag'] != None
-          - output.firewalls[0]['application_rule_collections'] | length == 1
-          - output.firewalls[0]['nat_rule_collections'] | length == 1
-          - output.firewalls[0]['network_rule_collections'] | length == 1
-          - output.firewalls[0]['ip_configurations'] | length == 1
-          - output.firewalls[0]['provisioning_state'] == 'Succeeded'
-          - output.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
-          - output.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.4,10.0.0.5'
-          - output.firewalls[0].sku is defined
-          - output.firewalls[0].sku.name is defined
-          - output.firewalls[0].threat_intel_mode is defined
+          - output.firewalls['id'] | length > 0
+          - output.firewalls['name'] == azure_firewall_name
+          - output.firewalls['resource_group'] == resource_group ~ '-azurefirewall'
+          - output.firewalls['location'] != None
+          - output.firewalls['etag'] != None
+          - output.firewalls['application_rule_collections'] | length == 1
+          - output.firewalls['nat_rule_collections'] | length == 1
+          - output.firewalls['network_rule_collections'] | length == 1
+          - output.firewalls['ip_configurations'] | length == 1
+          - output.firewalls['provisioning_state'] == 'Succeeded'
+          - output.firewalls.additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - output.firewalls.additional_properties['Network.DNS.Servers'] == '10.0.0.4,10.0.0.5'
+          - output.firewalls.sku is defined
+          - output.firewalls.sku.name is defined
+          - output.firewalls.threat_intel_mode is defined
 
     - name: List Azure Firewalls in resource group
       azure.azcollection.azure_rm_azurefirewall_info:
@@ -468,9 +467,8 @@
     - name: Assert DNS server change is reflected via info
       ansible.builtin.assert:
         that:
-          - dns_change_info.firewalls | length == 1
-          - dns_change_info.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
-          - dns_change_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.6'
+          - dns_change_info.firewalls.additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - dns_change_info.firewalls.additional_properties['Network.DNS.Servers'] == '10.0.0.6'
 
     - name: Re-apply the same DNS server change -- idempotent
       azure.azcollection.azure_rm_azurefirewall:
@@ -515,9 +513,8 @@
     - name: Assert DNS server value survived the drift merge
       ansible.builtin.assert:
         that:
-          - dns_drift_info.firewalls | length == 1
-          - dns_drift_info.firewalls[0].additional_properties['Network.DNS.EnableProxy'] == 'true'
-          - dns_drift_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.6'
+          - dns_drift_info.firewalls.additional_properties['Network.DNS.EnableProxy'] == 'true'
+          - dns_drift_info.firewalls.additional_properties['Network.DNS.Servers'] == '10.0.0.6'
 
     - name: Re-apply full body with network rules in reversed order
       azure.azcollection.azure_rm_azurefirewall:
@@ -595,15 +592,14 @@
     - name: Assert info confirms every top-level collection survived the partial update
       ansible.builtin.assert:
         that:
-          - partial_apply_info.firewalls | length == 1
-          - partial_apply_info.firewalls[0].additional_properties['Network.DNS.Servers'] == '10.0.0.7'
-          - partial_apply_info.firewalls[0].application_rule_collections | length == 1
-          - partial_apply_info.firewalls[0].nat_rule_collections | length == 1
-          - partial_apply_info.firewalls[0].network_rule_collections | length == 1
-          - partial_apply_info.firewalls[0].network_rule_collections[0].rules | length == 2
-          - partial_apply_info.firewalls[0].ip_configurations | length == 1
-          - partial_apply_info.firewalls[0].sku.name == 'AZFW_VNet'
-          - partial_apply_info.firewalls[0].threat_intel_mode == 'Alert'
+          - partial_apply_info.firewalls.additional_properties['Network.DNS.Servers'] == '10.0.0.7'
+          - partial_apply_info.firewalls.application_rule_collections | length == 1
+          - partial_apply_info.firewalls.nat_rule_collections | length == 1
+          - partial_apply_info.firewalls.network_rule_collections | length == 1
+          - partial_apply_info.firewalls.network_rule_collections[0].properties.rules | length == 2
+          - partial_apply_info.firewalls.ip_configurations | length == 1
+          - partial_apply_info.firewalls.sku.name == 'AZFW_VNet'
+          - partial_apply_info.firewalls.threat_intel_mode == 'Alert'
 
     - name: Re-apply the same partial DNS body -- idempotent
       azure.azcollection.azure_rm_azurefirewall:


### PR DESCRIPTION
##### SUMMARY
Fix #304, #2357.
Both `azure_rm_azurefirewall` and `azure_rm_azurefirewall_info` move from the deprecated ARM `deploy_template` lifecycle to native `azure_firewalls` operations on `azure-mgmt-network`. The stateful module gains `dns_servers` and `dns_proxy_enabled` options wired through the SDK's `additional_properties` map, and `exec_module` now back-fills every unmanaged top-level field before PUT so partial updates cannot silently wipe firewall state.

##### ISSUE TYPE
- [x] New Feature Pull Request
- [ ] New Module Pull Request
- [ ] Bug Fix Pull Request
- [ ] Test Fix Pull Request
- [x] Migration Pull Request
- [ ] Documentation Pull Request

##### COMPONENT NAME
- plugins/modules/azure_rm_azurefirewall.py
- plugins/modules/azure_rm_azurefirewall_info.py
- tests/integration/targets/azure_rm_azurefirewall/tasks/main.yml

##### ADDITIONAL INFORMATION
- Both modules migrated from `deploy_template` ARM lifecycle to `azure_firewalls.begin_create_or_update` / `.get` / `.list` / `.list_all` on `azure-mgmt-network` v2024-01-01.
- New options on `azure_rm_azurefirewall`: `dns_servers` (list of str) and `dns_proxy_enabled` (bool), persisted via `additional_properties` keys `Network.DNS.Servers` and `Network.DNS.EnableProxy` per the Azure Firewall REST spec.
- `exec_module` back-fills every top-level `AzureFirewall` SDK field the user did not supply (`application_rule_collections`, `nat_rule_collections`, `network_rule_collections`, `ip_configurations`, `sku`, `firewall_policy`, `threat_intel_mode`, `virtual_hub`, `zones`, `hub_ip_addresses`, `management_ip_configuration`, `autoscale_configuration`) from the existing firewall before PUT, so partial updates cannot clear collections or unmanaged state the user did not intend to touch.
- `additional_properties` is merged with the existing firewall so out-of-band keys (SNAT ranges, FTP flags, threat-intel allowlist, etc.) survive Ansible updates.
- Rule collections, their rules, and ip_configurations are pre-sorted by `name` before `default_compare` so Azure's return order no longer produces false-positive `changed=true`.
- `resolve_public_ip_id` accepts a bare name in the current resource group and constructs the full ARM ID via `azure.mgmt.core.tools.resource_id`; ARM IDs pass through unchanged via `is_valid_resource_id`.
- `resolve_subnet_id` validates the string form via `is_valid_resource_id` and fails fast with a clear error when given a bare non-ID name, matching the sibling `is_valid_resource_id` pattern in `azure_rm_appgateway`, `azure_rm_networkinterface`, and `azure_rm_subnet`.
- `RETURN` blocks on both modules now document `additional_properties`, `sku`, and `threat_intel_mode` to match `firewall.as_dict()`.
- 404-as-absent: `.get()` catches `ResourceNotFoundError` and returns `None` (stateful) / `[]` (info) so missing-firewall reads and delete-idempotence work correctly.
- Breaking: `azure_rm_azurefirewall_info` now returns `firewalls` as a list of dicts (matching the module's actual pre-refactor code behavior and the fixed RETURN doc). Playbooks that indexed `firewalls['someName']` must switch to `firewalls | selectattr('name', 'equalto', 'foo') | first`.
- Integration coverage extended: state envelope shape, info envelope, DNS proxy CRUD, drift preservation, reorder idempotence, partial-body back-fill, delete idempotence, missing-firewall info.

##### REFERENCE
- https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/network/azure-mgmt-network/azure/mgmt/network/v2024_01_01
- https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/stable/2024-01-01/azureFirewall.json