### PR TITLE
Add support for Microsoft.Network/dnsResolvers subnet delegation

### DIFF
--- a/plugins/modules/azure_rm_subnet.py
+++ b/plugins/modules/azure_rm_subnet.py
@@ -154,6 +154,7 @@ options:
                     - Microsoft.ApiManagement/service
                     - Microsoft.Synapse/workspaces
                     - Microsoft.PowerPlatform/vnetaccesslinks
+                    - Microsoft.Network/dnsResolvers
                     - Microsoft.Network/managedResolvers
                     - Microsoft.Kusto/clusters
                     - Microsoft.App/environments
@@ -242,6 +243,16 @@ EXAMPLES = '''
     delegations:
       - name: 'mydeleg'
         serviceName: 'Microsoft.ContainerInstance/containerGroups'
+
+- name: Create a subnet with DNS resolver delegation
+  azure_rm_subnet:
+    resource_group: myResourceGroup
+    virtual_network_name: myVirtualNetwork
+    name: myDnsResolverSubnet
+    address_prefix_cidr: "10.1.1.0/28"
+    delegations:
+      - name: 'Microsoft.Network/dnsResolvers'
+        serviceName: 'Microsoft.Network/dnsResolvers'
 
 - name: Create a subnet with an associated NAT Gateway
   azure_rm_subnet:
@@ -397,8 +408,8 @@ delegations_spec = dict(
                  'Microsoft.DBforPostgreSQL/serversv2', 'Microsoft.AzureCosmosDB/clusters', 'Microsoft.MachineLearningServices/workspaces',
                  'Microsoft.DBforPostgreSQL/singleServers', 'Microsoft.DBforPostgreSQL/flexibleServers', 'Microsoft.DBforMySQL/serversv2',
                  'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.ApiManagement/service', 'Microsoft.Synapse/workspaces',
-                 'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/managedResolvers', 'Microsoft.Kusto/clusters',
-                 'Microsoft.ContainerService/managedClusters', 'Microsoft.App/environments',
+                 'Microsoft.PowerPlatform/vnetaccesslinks', 'Microsoft.Network/dnsResolvers', 'Microsoft.Network/managedResolvers',
+                 'Microsoft.Kusto/clusters', 'Microsoft.ContainerService/managedClusters', 'Microsoft.App/environments',
                  'Microsoft.Network/applicationGateways',
                  'Microsoft.ServiceNetworking/trafficControllers']
     ),

--- a/tests/integration/targets/azure_rm_subnet/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_subnet/tasks/main.yml
@@ -273,6 +273,34 @@
       ansible.builtin.assert:
         that: output is not changed
 
+    - name: Update the subnet with DNS resolver delegation
+      azure.azcollection.azure_rm_subnet:
+        name: foobar01
+        virtual_network_name: My_Virtual_Network
+        resource_group: "{{ resource_group }}-sub01"
+        delegations:
+          - name: 'Microsoft.Network/dnsResolvers'
+            serviceName: 'Microsoft.Network/dnsResolvers'
+      register: output
+
+    - name: Assert the subnet updated with DNS resolver delegation
+      ansible.builtin.assert:
+        that: output is changed
+
+    - name: The subnet with DNS resolver delegation should be idempotent
+      azure.azcollection.azure_rm_subnet:
+        name: foobar01
+        virtual_network_name: My_Virtual_Network
+        resource_group: "{{ resource_group }}-sub01"
+        delegations:
+          - name: 'Microsoft.Network/dnsResolvers'
+            serviceName: 'Microsoft.Network/dnsResolvers'
+      register: output
+
+    - name: Assert idempotent
+      ansible.builtin.assert:
+        that: output is not changed
+
     - name: Get subnet facts
       azure.azcollection.azure_rm_subnet_info:
         name: foobar01


### PR DESCRIPTION
## Summary

Adds support for the `Microsoft.Network/dnsResolvers` subnet delegation option to the `azure_rm_subnet` module.

## Issue

Fixes https://redhat.atlassian.net/browse/AAP-76653

## Description

The `azure_rm_subnet` module had a hardcoded list of allowed subnet delegations that was missing `Microsoft.Network/dnsResolvers`. This delegation is required for Azure Private DNS Resolver configurations and is available in the Azure Portal, Azure API, and Terraform provider.

## Changes

- Added `Microsoft.Network/dnsResolvers` to the allowed delegation choices in both the DOCUMENTATION and `delegations_spec`
- Added an example in EXAMPLES showing DNS resolver delegation usage
- Added integration tests for DNS resolver delegation with idempotency checks

## Test Plan

- [x] Updated integration tests in `tests/integration/targets/azure_rm_subnet/tasks/main.yml`
- [x] Tests verify delegation can be set and is idempotent

## Backward Compatibility

This change is backward compatible - it only adds a new option to the existing `serviceName` choices.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)